### PR TITLE
Run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/pkoukk/tiktoken-go
 go 1.19
 
 require (
+	github.com/dlclark/regexp2 v1.8.1
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dlclark/regexp2 v1.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
I noticed that `regexp2` is used in the code, but was in the `go.mod` only as transitive dependency, which seemed wrong. Indeed when running `go mod tidy` it's changed to a direct dependency.