### PR TITLE
Optimize encodeNative()

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,43 @@
+package tiktoken
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+const TEST_FILE = "test/test.txt"
+
+func ReadTestFile() ([]byte, error) {
+	// open and read TEST_FILE
+	return ioutil.ReadFile(TEST_FILE)
+}
+
+func BenchmarkEncoding(b *testing.B) {
+	fileContent, err := ReadTestFile()
+	if err != nil {
+		panic(err)
+	}
+
+	tkm, err := EncodingForModel("gpt-4")
+	if err != nil {
+		panic(err)
+	}
+
+	text := string(fileContent)
+
+	for ordersOfMagnitude := 0; ordersOfMagnitude < 4; ordersOfMagnitude++ {
+		// do actual encoding
+		fmt.Printf("Encoding %d bytes\n", len(text))
+		tkm.Encode(text, nil, nil)
+
+		stringBuilder := strings.Builder{}
+		for i := 0; i < 10; i++ {
+			stringBuilder.WriteString(text)
+		}
+
+		text = stringBuilder.String()
+	}
+
+}

--- a/core_bpe.go
+++ b/core_bpe.go
@@ -74,6 +74,7 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 	regex := bp.tlRegex
 	ret := []int{}
 	lastPieceTokenLen := 0
+	textRunes := []rune(text)
 
 	start := 0
 	for {
@@ -81,10 +82,10 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 		startFind := start
 		for {
 			// Find the next allowed special token, if any
-			temp := cutTextInRune(text, startFind, len([]rune(text)))
+			temp := cutRunes(textRunes, startFind, len(textRunes))
 			nextSpecial = findRegex2StringIndex(temp, specialRegex)
 			if nextSpecial != nil {
-				token := cutTextInRune(text, startFind+nextSpecial[0], startFind+nextSpecial[1])
+				token := cutRunes(textRunes, startFind+nextSpecial[0], startFind+nextSpecial[1])
 				if _, ok := allowedSpecial[token]; ok {
 					break
 				}
@@ -100,8 +101,8 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 		}
 
 		// Okay, here we go, compare this logic to _encode_ordinary_native
-		for _, mat := range findRegex2AllStringMatchIndex(cutTextInRune(text, start, end), regex) {
-			piece := cutTextInRune(text, start+mat[0], start+mat[1])
+		for _, mat := range findRegex2AllStringMatchIndex(cutRunes(textRunes, start, end), regex) {
+			piece := cutRunes(textRunes, start+mat[0], start+mat[1])
 			if token, ok := bp.encoder[piece]; ok {
 				lastPieceTokenLen = 1
 				ret = append(ret, token)
@@ -113,7 +114,7 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 		}
 
 		if nextSpecial != nil {
-			temp := cutTextInRune(text, start+nextSpecial[0], start+nextSpecial[1])
+			temp := cutRunes(textRunes, start+nextSpecial[0], start+nextSpecial[1])
 			token := bp.specialTokensEncoder[temp]
 			ret = append(ret, token)
 			start = start + nextSpecial[1]
@@ -164,8 +165,7 @@ func findRegex2AllStringMatchIndex(text string, reg *regexp2.Regexp) [][]int {
 	return matches
 }
 
-func cutTextInRune(text string, start, end int) string {
-	runes := []rune(text)
+func cutRunes(runes []rune, start, end int) string {
 	if start < 0 {
 		start = 0
 	}


### PR DESCRIPTION
I was using this encoder for https://github.com/bakks/butterfish and found that the encoder scales very poorly as the string gets longer. I did a CPU profile (see image below) and found that the most expensive operation was this specific line: https://github.com/pkoukk/tiktoken-go/blob/03647ca046a15c80510e2a135a2dacdf31320ca1/core_bpe.go#L168

<img width="515" alt="Screen Shot 2023-06-01 at 6 58 18 PM" src="https://github.com/pkoukk/tiktoken-go/assets/1172710/7394d470-d4f8-4f11-9b2d-819c9b32ce03">

The `encodeNative()` function calls `cutTextInRune()` a bunch of times, which casts a `string` to `[]rune`. That cast probably copies everything in memory, which for a small string is pretty negligible but if the string gets longer then it becomes more expensive. And this cast is being duplicated on the same string unnecessarily, so it currently scales superlinearly with string size, i.e. as the strings get longer it gets very very slow.

I made some changes and benchmarked the results. For a string of ~589000 bytes the old implementation basically never finishes, the new implementation takes about 0.2 seconds.

Please double check me and merge if useful.

