### PR TITLE
Merge `main` updates into `embed` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ import (
     "github.com/pkoukk/tiktoken-go"
 )
 
-func main() (num_tokens int) {
-    text = "Hello, world!"
-    encoding = "r50k_base"
+func main()  {
+	text := "Hello, world!"
+	encoding := "cl100k_base"
 
 	tke, err := tiktoken.GetEncoding(encoding)
 	if err != nil {
@@ -48,11 +48,13 @@ func main() (num_tokens int) {
 		return
 	}
 
-    // encode
+	// encode
 	token := tke.Encode(text, nil, nil)
 
-    // num_tokens
-    num_tokens = len(token)
+	//tokens
+	fmt.Println((token))
+	// num_tokens
+	fmt.Println(len(token))
 }
 ```
 
@@ -66,21 +68,23 @@ import (
     "github.com/pkoukk/tiktoken-go"
 )
 
-func main() (num_tokens int) {
-    text = "Hello, world!"
-    encoding = "davinci"
+func main()  {
+	text := "Hello, world!"
+	encoding := "gpt-3.5-turbo"
 
-   tkm, err := tiktoken.EncodingForModel(model)
+	tkm, err := tiktoken.EncodingForModel(encoding)
 	if err != nil {
 		err = fmt.Errorf("getEncoding: %v", err)
 		return
 	}
 
-	 // encode
-	token := tke.Encode(text, nil, nil)
+	// encode
+	token := tkm.Encode(text, nil, nil)
 
-    // num_tokens
-    num_tokens = len(token)
+	// tokens
+	fmt.Println(token)
+	// num_tokens
+	fmt.Println(len(token))
 }
 ```
 ### counting tokens for chat API calls
@@ -131,6 +135,7 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 		num_tokens += tokens_per_message
 		num_tokens += len(tkm.Encode(message.Content, nil, nil))
 		num_tokens += len(tkm.Encode(message.Role, nil, nil))
+		num_tokens += len(tkm.Encode(message.Name,nil,nil))
 		if message.Name != "" {
 			num_tokens += tokens_per_name
 		}
@@ -191,372 +196,34 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 
 
 # Test
-> you can run text in [test](./test) folder
-
+> you can run test in [test](./test) folder
 
 # compare with original [tiktoken](https://github.com/openai/tiktoken)
 
 ## get token by encoding
-
-| python tiktoken                                          | golang tiktoken-go                                       |
-| :------------------------------------------------------- | :------------------------------------------------------- |
-| text: hallo world!, encoding: cl100k_base, token: 4      | text: hallo world!, encoding: cl100k_base, token: 4      |
-| text: hallo world!, encoding: p50k_base, token: 4        | text: hallo world!, encoding: p50k_base, token: 4        |
-| text: hallo world!, encoding: r50k_base, token: 4        | text: hallo world!, encoding: r50k_base, token: 4        |
-| text: 你好世界！, encoding: cl100k_base, token: 6        | text: 你好世界！, encoding: cl100k_base, token: 6        |
-| text: 你好世界！, encoding: p50k_base, token: 11         | text: 你好世界！, encoding: p50k_base, token: 11         |
-| text: 你好世界！, encoding: r50k_base, token: 11         | text: 你好世界！, encoding: r50k_base, token: 11         |
-| text: こんにちは世界！, encoding: cl100k_base, token: 5  | text: こんにちは世界！, encoding: cl100k_base, token: 5  |
-| text: こんにちは世界！, encoding: p50k_base, token: 13   | text: こんにちは世界！, encoding: p50k_base, token: 13   |
-| text: こんにちは世界！, encoding: r50k_base, token: 13   | text: こんにちは世界！, encoding: r50k_base, token: 13   |
-| text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 | text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 |
-| text: 안녕하세요 세계!, encoding: p50k_base, token: 21   | text: 안녕하세요 세계!, encoding: p50k_base, token: 21   |
-| text: 안녕하세요 세계!, encoding: r50k_base, token: 21   | text: 안녕하세요 세계!, encoding: r50k_base, token: 21   |
-| text: Привет мир!, encoding: cl100k_base, token: 6       | text: Привет мир!, encoding: cl100k_base, token: 6       |
-| text: Привет мир!, encoding: p50k_base, token: 12        | text: Привет мир!, encoding: p50k_base, token: 12        |
-| text: Привет мир!, encoding: r50k_base, token: 12        | text: Привет мир!, encoding: r50k_base, token: 12        |
-| text: ¡Hola mundo!, encoding: cl100k_base, token: 4      | text: ¡Hola mundo!, encoding: cl100k_base, token: 4      |
-| text: ¡Hola mundo!, encoding: p50k_base, token: 7        | text: ¡Hola mundo!, encoding: p50k_base, token: 7        |
-| text: ¡Hola mundo!, encoding: r50k_base, token: 7        | text: ¡Hola mundo!, encoding: r50k_base, token: 7        |
-| text: Hallo Welt!, encoding: cl100k_base, token: 3       | text: Hallo Welt!, encoding: cl100k_base, token: 3       |
-| text: Hallo Welt!, encoding: p50k_base, token: 5         | text: Hallo Welt!, encoding: p50k_base, token: 5         |
-| text: Hallo Welt!, encoding: r50k_base, token: 5         | text: Hallo Welt!, encoding: r50k_base, token: 5         |
-| text: Bonjour le monde!, encoding: cl100k_base, token: 4 | text: Bonjour le monde!, encoding: cl100k_base, token: 4 |
-| text: Bonjour le monde!, encoding: p50k_base, token: 7   | text: Bonjour le monde!, encoding: p50k_base, token: 7   |
-| text: Bonjour le monde!, encoding: r50k_base, token: 7   | text: Bonjour le monde!, encoding: r50k_base, token: 7   |
-| text: Ciao mondo!, encoding: cl100k_base, token: 4       | text: Ciao mondo!, encoding: cl100k_base, token: 4       |
-| text: Ciao mondo!, encoding: p50k_base, token: 5         | text: Ciao mondo!, encoding: p50k_base, token: 5         |
-| text: Ciao mondo!, encoding: r50k_base, token: 5         | text: Ciao mondo!, encoding: r50k_base, token: 5         |
-| text: Hej världen!, encoding: cl100k_base, token: 7      | text: Hej världen!, encoding: cl100k_base, token: 7      |
-| text: Hej världen!, encoding: p50k_base, token: 8        | text: Hej världen!, encoding: p50k_base, token: 8        |
-| text: Hej världen!, encoding: r50k_base, token: 8        | text: Hej världen!, encoding: r50k_base, token: 8        |
-| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
-| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
-| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
-| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
-| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
-| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
-| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
-| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
-| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
-| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
-| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
-| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
-
+[result](./doc/test_result.md#encoding-test-result)
 
 ## get token by model  
+[result](./doc/test_result.md#model-test-result)
 
-| python tiktoken                                                       | golang tiktoken-go                                                    |
-| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| text: hallo world!, model: gpt-4, token: 4                            | text: hallo world!, model: gpt-4, token: 4                            |
-| text: hallo world!, model: gpt-3.5-turbo, token: 4                    | text: hallo world!, model: gpt-3.5-turbo, token: 4                    |
-| text: hallo world!, model: text-davinci-003, token: 4                 | text: hallo world!, model: text-davinci-003, token: 4                 |
-| text: hallo world!, model: text-davinci-002, token: 4                 | text: hallo world!, model: text-davinci-002, token: 4                 |
-| text: hallo world!, model: text-davinci-001, token: 4                 | text: hallo world!, model: text-davinci-001, token: 4                 |
-| text: hallo world!, model: text-curie-001, token: 4                   | text: hallo world!, model: text-curie-001, token: 4                   |
-| text: hallo world!, model: text-babbage-001, token: 4                 | text: hallo world!, model: text-babbage-001, token: 4                 |
-| text: hallo world!, model: text-ada-001, token: 4                     | text: hallo world!, model: text-ada-001, token: 4                     |
-| text: hallo world!, model: davinci, token: 4                          | text: hallo world!, model: davinci, token: 4                          |
-| text: hallo world!, model: curie, token: 4                            | text: hallo world!, model: curie, token: 4                            |
-| text: hallo world!, model: babbage, token: 4                          | text: hallo world!, model: babbage, token: 4                          |
-| text: hallo world!, model: ada, token: 4                              | text: hallo world!, model: ada, token: 4                              |
-| text: hallo world!, model: code-davinci-002, token: 4                 | text: hallo world!, model: code-davinci-002, token: 4                 |
-| text: hallo world!, model: code-davinci-001, token: 4                 | text: hallo world!, model: code-davinci-001, token: 4                 |
-| text: hallo world!, model: code-cushman-002, token: 4                 | text: hallo world!, model: code-cushman-002, token: 4                 |
-| text: hallo world!, model: code-cushman-001, token: 4                 | text: hallo world!, model: code-cushman-001, token: 4                 |
-| text: hallo world!, model: davinci-codex, token: 4                    | text: hallo world!, model: davinci-codex, token: 4                    |
-| text: hallo world!, model: cushman-codex, token: 4                    | text: hallo world!, model: cushman-codex, token: 4                    |
-| text: hallo world!, model: text-davinci-edit-001, token: 4            | text: hallo world!, model: text-davinci-edit-001, token: 4            |
-| text: hallo world!, model: code-davinci-edit-001, token: 4            | text: hallo world!, model: code-davinci-edit-001, token: 4            |
-| text: hallo world!, model: text-embedding-ada-002, token: 4           | text: hallo world!, model: text-embedding-ada-002, token: 4           |
-| text: hallo world!, model: text-similarity-davinci-001, token: 4      | text: hallo world!, model: text-similarity-davinci-001, token: 4      |
-| text: 你好世界！, model: gpt-4, token: 6                              | text: 你好世界！, model: gpt-4, token: 6                              |
-| text: 你好世界！, model: gpt-3.5-turbo, token: 6                      | text: 你好世界！, model: gpt-3.5-turbo, token: 6                      |
-| text: 你好世界！, model: text-davinci-003, token: 11                  | text: 你好世界！, model: text-davinci-003, token: 11                  |
-| text: 你好世界！, model: text-davinci-002, token: 11                  | text: 你好世界！, model: text-davinci-002, token: 11                  |
-| text: 你好世界！, model: text-davinci-001, token: 11                  | text: 你好世界！, model: text-davinci-001, token: 11                  |
-| text: 你好世界！, model: text-curie-001, token: 11                    | text: 你好世界！, model: text-curie-001, token: 11                    |
-| text: 你好世界！, model: text-babbage-001, token: 11                  | text: 你好世界！, model: text-babbage-001, token: 11                  |
-| text: 你好世界！, model: text-ada-001, token: 11                      | text: 你好世界！, model: text-ada-001, token: 11                      |
-| text: 你好世界！, model: davinci, token: 11                           | text: 你好世界！, model: davinci, token: 11                           |
-| text: 你好世界！, model: curie, token: 11                             | text: 你好世界！, model: curie, token: 11                             |
-| text: 你好世界！, model: babbage, token: 11                           | text: 你好世界！, model: babbage, token: 11                           |
-| text: 你好世界！, model: ada, token: 11                               | text: 你好世界！, model: ada, token: 11                               |
-| text: 你好世界！, model: code-davinci-002, token: 11                  | text: 你好世界！, model: code-davinci-002, token: 11                  |
-| text: 你好世界！, model: code-davinci-001, token: 11                  | text: 你好世界！, model: code-davinci-001, token: 11                  |
-| text: 你好世界！, model: code-cushman-002, token: 11                  | text: 你好世界！, model: code-cushman-002, token: 11                  |
-| text: 你好世界！, model: code-cushman-001, token: 11                  | text: 你好世界！, model: code-cushman-001, token: 11                  |
-| text: 你好世界！, model: davinci-codex, token: 11                     | text: 你好世界！, model: davinci-codex, token: 11                     |
-| text: 你好世界！, model: cushman-codex, token: 11                     | text: 你好世界！, model: cushman-codex, token: 11                     |
-| text: 你好世界！, model: text-davinci-edit-001, token: 11             | text: 你好世界！, model: text-davinci-edit-001, token: 11             |
-| text: 你好世界！, model: code-davinci-edit-001, token: 11             | text: 你好世界！, model: code-davinci-edit-001, token: 11             |
-| text: 你好世界！, model: text-embedding-ada-002, token: 6             | text: 你好世界！, model: text-embedding-ada-002, token: 6             |
-| text: 你好世界！, model: text-similarity-davinci-001, token: 11       | text: 你好世界！, model: text-similarity-davinci-001, token: 11       |
-| text: こんにちは世界！, model: gpt-4, token: 5                        | text: こんにちは世界！, model: gpt-4, token: 5                        |
-| text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                | text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                |
-| text: こんにちは世界！, model: text-davinci-003, token: 13            | text: こんにちは世界！, model: text-davinci-003, token: 13            |
-| text: こんにちは世界！, model: text-davinci-002, token: 13            | text: こんにちは世界！, model: text-davinci-002, token: 13            |
-| text: こんにちは世界！, model: text-davinci-001, token: 13            | text: こんにちは世界！, model: text-davinci-001, token: 13            |
-| text: こんにちは世界！, model: text-curie-001, token: 13              | text: こんにちは世界！, model: text-curie-001, token: 13              |
-| text: こんにちは世界！, model: text-babbage-001, token: 13            | text: こんにちは世界！, model: text-babbage-001, token: 13            |
-| text: こんにちは世界！, model: text-ada-001, token: 13                | text: こんにちは世界！, model: text-ada-001, token: 13                |
-| text: こんにちは世界！, model: davinci, token: 13                     | text: こんにちは世界！, model: davinci, token: 13                     |
-| text: こんにちは世界！, model: curie, token: 13                       | text: こんにちは世界！, model: curie, token: 13                       |
-| text: こんにちは世界！, model: babbage, token: 13                     | text: こんにちは世界！, model: babbage, token: 13                     |
-| text: こんにちは世界！, model: ada, token: 13                         | text: こんにちは世界！, model: ada, token: 13                         |
-| text: こんにちは世界！, model: code-davinci-002, token: 13            | text: こんにちは世界！, model: code-davinci-002, token: 13            |
-| text: こんにちは世界！, model: code-davinci-001, token: 13            | text: こんにちは世界！, model: code-davinci-001, token: 13            |
-| text: こんにちは世界！, model: code-cushman-002, token: 13            | text: こんにちは世界！, model: code-cushman-002, token: 13            |
-| text: こんにちは世界！, model: code-cushman-001, token: 13            | text: こんにちは世界！, model: code-cushman-001, token: 13            |
-| text: こんにちは世界！, model: davinci-codex, token: 13               | text: こんにちは世界！, model: davinci-codex, token: 13               |
-| text: こんにちは世界！, model: cushman-codex, token: 13               | text: こんにちは世界！, model: cushman-codex, token: 13               |
-| text: こんにちは世界！, model: text-davinci-edit-001, token: 13       | text: こんにちは世界！, model: text-davinci-edit-001, token: 13       |
-| text: こんにちは世界！, model: code-davinci-edit-001, token: 13       | text: こんにちは世界！, model: code-davinci-edit-001, token: 13       |
-| text: こんにちは世界！, model: text-embedding-ada-002, token: 5       | text: こんにちは世界！, model: text-embedding-ada-002, token: 5       |
-| text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 | text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 |
-| text: 안녕하세요 세계!, model: gpt-4, token: 10                       | text: 안녕하세요 세계!, model: gpt-4, token: 10                       |
-| text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               | text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               |
-| text: 안녕하세요 세계!, model: text-davinci-003, token: 21            | text: 안녕하세요 세계!, model: text-davinci-003, token: 21            |
-| text: 안녕하세요 세계!, model: text-davinci-002, token: 21            | text: 안녕하세요 세계!, model: text-davinci-002, token: 21            |
-| text: 안녕하세요 세계!, model: text-davinci-001, token: 21            | text: 안녕하세요 세계!, model: text-davinci-001, token: 21            |
-| text: 안녕하세요 세계!, model: text-curie-001, token: 21              | text: 안녕하세요 세계!, model: text-curie-001, token: 21              |
-| text: 안녕하세요 세계!, model: text-babbage-001, token: 21            | text: 안녕하세요 세계!, model: text-babbage-001, token: 21            |
-| text: 안녕하세요 세계!, model: text-ada-001, token: 21                | text: 안녕하세요 세계!, model: text-ada-001, token: 21                |
-| text: 안녕하세요 세계!, model: davinci, token: 21                     | text: 안녕하세요 세계!, model: davinci, token: 21                     |
-| text: 안녕하세요 세계!, model: curie, token: 21                       | text: 안녕하세요 세계!, model: curie, token: 21                       |
-| text: 안녕하세요 세계!, model: babbage, token: 21                     | text: 안녕하세요 세계!, model: babbage, token: 21                     |
-| text: 안녕하세요 세계!, model: ada, token: 21                         | text: 안녕하세요 세계!, model: ada, token: 21                         |
-| text: 안녕하세요 세계!, model: code-davinci-002, token: 21            | text: 안녕하세요 세계!, model: code-davinci-002, token: 21            |
-| text: 안녕하세요 세계!, model: code-davinci-001, token: 21            | text: 안녕하세요 세계!, model: code-davinci-001, token: 21            |
-| text: 안녕하세요 세계!, model: code-cushman-002, token: 21            | text: 안녕하세요 세계!, model: code-cushman-002, token: 21            |
-| text: 안녕하세요 세계!, model: code-cushman-001, token: 21            | text: 안녕하세요 세계!, model: code-cushman-001, token: 21            |
-| text: 안녕하세요 세계!, model: davinci-codex, token: 21               | text: 안녕하세요 세계!, model: davinci-codex, token: 21               |
-| text: 안녕하세요 세계!, model: cushman-codex, token: 21               | text: 안녕하세요 세계!, model: cushman-codex, token: 21               |
-| text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       |
-| text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       |
-| text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      | text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      |
-| text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 | text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 |
-| text: Привет мир!, model: gpt-4, token: 6                             | text: Привет мир!, model: gpt-4, token: 6                             |
-| text: Привет мир!, model: gpt-3.5-turbo, token: 6                     | text: Привет мир!, model: gpt-3.5-turbo, token: 6                     |
-| text: Привет мир!, model: text-davinci-003, token: 12                 | text: Привет мир!, model: text-davinci-003, token: 12                 |
-| text: Привет мир!, model: text-davinci-002, token: 12                 | text: Привет мир!, model: text-davinci-002, token: 12                 |
-| text: Привет мир!, model: text-davinci-001, token: 12                 | text: Привет мир!, model: text-davinci-001, token: 12                 |
-| text: Привет мир!, model: text-curie-001, token: 12                   | text: Привет мир!, model: text-curie-001, token: 12                   |
-| text: Привет мир!, model: text-babbage-001, token: 12                 | text: Привет мир!, model: text-babbage-001, token: 12                 |
-| text: Привет мир!, model: text-ada-001, token: 12                     | text: Привет мир!, model: text-ada-001, token: 12                     |
-| text: Привет мир!, model: davinci, token: 12                          | text: Привет мир!, model: davinci, token: 12                          |
-| text: Привет мир!, model: curie, token: 12                            | text: Привет мир!, model: curie, token: 12                            |
-| text: Привет мир!, model: babbage, token: 12                          | text: Привет мир!, model: babbage, token: 12                          |
-| text: Привет мир!, model: ada, token: 12                              | text: Привет мир!, model: ada, token: 12                              |
-| text: Привет мир!, model: code-davinci-002, token: 12                 | text: Привет мир!, model: code-davinci-002, token: 12                 |
-| text: Привет мир!, model: code-davinci-001, token: 12                 | text: Привет мир!, model: code-davinci-001, token: 12                 |
-| text: Привет мир!, model: code-cushman-002, token: 12                 | text: Привет мир!, model: code-cushman-002, token: 12                 |
-| text: Привет мир!, model: code-cushman-001, token: 12                 | text: Привет мир!, model: code-cushman-001, token: 12                 |
-| text: Привет мир!, model: davinci-codex, token: 12                    | text: Привет мир!, model: davinci-codex, token: 12                    |
-| text: Привет мир!, model: cushman-codex, token: 12                    | text: Привет мир!, model: cushman-codex, token: 12                    |
-| text: Привет мир!, model: text-davinci-edit-001, token: 12            | text: Привет мир!, model: text-davinci-edit-001, token: 12            |
-| text: Привет мир!, model: code-davinci-edit-001, token: 12            | text: Привет мир!, model: code-davinci-edit-001, token: 12            |
-| text: Привет мир!, model: text-embedding-ada-002, token: 6            | text: Привет мир!, model: text-embedding-ada-002, token: 6            |
-| text: Привет мир!, model: text-similarity-davinci-001, token: 12      | text: Привет мир!, model: text-similarity-davinci-001, token: 12      |
-| text: ¡Hola mundo!, model: gpt-4, token: 4                            | text: ¡Hola mundo!, model: gpt-4, token: 4                            |
-| text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    | text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    |
-| text: ¡Hola mundo!, model: text-davinci-003, token: 7                 | text: ¡Hola mundo!, model: text-davinci-003, token: 7                 |
-| text: ¡Hola mundo!, model: text-davinci-002, token: 7                 | text: ¡Hola mundo!, model: text-davinci-002, token: 7                 |
-| text: ¡Hola mundo!, model: text-davinci-001, token: 7                 | text: ¡Hola mundo!, model: text-davinci-001, token: 7                 |
-| text: ¡Hola mundo!, model: text-curie-001, token: 7                   | text: ¡Hola mundo!, model: text-curie-001, token: 7                   |
-| text: ¡Hola mundo!, model: text-babbage-001, token: 7                 | text: ¡Hola mundo!, model: text-babbage-001, token: 7                 |
-| text: ¡Hola mundo!, model: text-ada-001, token: 7                     | text: ¡Hola mundo!, model: text-ada-001, token: 7                     |
-| text: ¡Hola mundo!, model: davinci, token: 7                          | text: ¡Hola mundo!, model: davinci, token: 7                          |
-| text: ¡Hola mundo!, model: curie, token: 7                            | text: ¡Hola mundo!, model: curie, token: 7                            |
-| text: ¡Hola mundo!, model: babbage, token: 7                          | text: ¡Hola mundo!, model: babbage, token: 7                          |
-| text: ¡Hola mundo!, model: ada, token: 7                              | text: ¡Hola mundo!, model: ada, token: 7                              |
-| text: ¡Hola mundo!, model: code-davinci-002, token: 7                 | text: ¡Hola mundo!, model: code-davinci-002, token: 7                 |
-| text: ¡Hola mundo!, model: code-davinci-001, token: 7                 | text: ¡Hola mundo!, model: code-davinci-001, token: 7                 |
-| text: ¡Hola mundo!, model: code-cushman-002, token: 7                 | text: ¡Hola mundo!, model: code-cushman-002, token: 7                 |
-| text: ¡Hola mundo!, model: code-cushman-001, token: 7                 | text: ¡Hola mundo!, model: code-cushman-001, token: 7                 |
-| text: ¡Hola mundo!, model: davinci-codex, token: 7                    | text: ¡Hola mundo!, model: davinci-codex, token: 7                    |
-| text: ¡Hola mundo!, model: cushman-codex, token: 7                    | text: ¡Hola mundo!, model: cushman-codex, token: 7                    |
-| text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            |
-| text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            |
-| text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           | text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           |
-| text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      | text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      |
-| text: Hallo Welt!, model: gpt-4, token: 3                             | text: Hallo Welt!, model: gpt-4, token: 3                             |
-| text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     | text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     |
-| text: Hallo Welt!, model: text-davinci-003, token: 5                  | text: Hallo Welt!, model: text-davinci-003, token: 5                  |
-| text: Hallo Welt!, model: text-davinci-002, token: 5                  | text: Hallo Welt!, model: text-davinci-002, token: 5                  |
-| text: Hallo Welt!, model: text-davinci-001, token: 5                  | text: Hallo Welt!, model: text-davinci-001, token: 5                  |
-| text: Hallo Welt!, model: text-curie-001, token: 5                    | text: Hallo Welt!, model: text-curie-001, token: 5                    |
-| text: Hallo Welt!, model: text-babbage-001, token: 5                  | text: Hallo Welt!, model: text-babbage-001, token: 5                  |
-| text: Hallo Welt!, model: text-ada-001, token: 5                      | text: Hallo Welt!, model: text-ada-001, token: 5                      |
-| text: Hallo Welt!, model: davinci, token: 5                           | text: Hallo Welt!, model: davinci, token: 5                           |
-| text: Hallo Welt!, model: curie, token: 5                             | text: Hallo Welt!, model: curie, token: 5                             |
-| text: Hallo Welt!, model: babbage, token: 5                           | text: Hallo Welt!, model: babbage, token: 5                           |
-| text: Hallo Welt!, model: ada, token: 5                               | text: Hallo Welt!, model: ada, token: 5                               |
-| text: Hallo Welt!, model: code-davinci-002, token: 5                  | text: Hallo Welt!, model: code-davinci-002, token: 5                  |
-| text: Hallo Welt!, model: code-davinci-001, token: 5                  | text: Hallo Welt!, model: code-davinci-001, token: 5                  |
-| text: Hallo Welt!, model: code-cushman-002, token: 5                  | text: Hallo Welt!, model: code-cushman-002, token: 5                  |
-| text: Hallo Welt!, model: code-cushman-001, token: 5                  | text: Hallo Welt!, model: code-cushman-001, token: 5                  |
-| text: Hallo Welt!, model: davinci-codex, token: 5                     | text: Hallo Welt!, model: davinci-codex, token: 5                     |
-| text: Hallo Welt!, model: cushman-codex, token: 5                     | text: Hallo Welt!, model: cushman-codex, token: 5                     |
-| text: Hallo Welt!, model: text-davinci-edit-001, token: 5             | text: Hallo Welt!, model: text-davinci-edit-001, token: 5             |
-| text: Hallo Welt!, model: code-davinci-edit-001, token: 5             | text: Hallo Welt!, model: code-davinci-edit-001, token: 5             |
-| text: Hallo Welt!, model: text-embedding-ada-002, token: 3            | text: Hallo Welt!, model: text-embedding-ada-002, token: 3            |
-| text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       | text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       |
-| text: Bonjour le monde!, model: gpt-4, token: 4                       | text: Bonjour le monde!, model: gpt-4, token: 4                       |
-| text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               | text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               |
-| text: Bonjour le monde!, model: text-davinci-003, token: 7            | text: Bonjour le monde!, model: text-davinci-003, token: 7            |
-| text: Bonjour le monde!, model: text-davinci-002, token: 7            | text: Bonjour le monde!, model: text-davinci-002, token: 7            |
-| text: Bonjour le monde!, model: text-davinci-001, token: 7            | text: Bonjour le monde!, model: text-davinci-001, token: 7            |
-| text: Bonjour le monde!, model: text-curie-001, token: 7              | text: Bonjour le monde!, model: text-curie-001, token: 7              |
-| text: Bonjour le monde!, model: text-babbage-001, token: 7            | text: Bonjour le monde!, model: text-babbage-001, token: 7            |
-| text: Bonjour le monde!, model: text-ada-001, token: 7                | text: Bonjour le monde!, model: text-ada-001, token: 7                |
-| text: Bonjour le monde!, model: davinci, token: 7                     | text: Bonjour le monde!, model: davinci, token: 7                     |
-| text: Bonjour le monde!, model: curie, token: 7                       | text: Bonjour le monde!, model: curie, token: 7                       |
-| text: Bonjour le monde!, model: babbage, token: 7                     | text: Bonjour le monde!, model: babbage, token: 7                     |
-| text: Bonjour le monde!, model: ada, token: 7                         | text: Bonjour le monde!, model: ada, token: 7                         |
-| text: Bonjour le monde!, model: code-davinci-002, token: 7            | text: Bonjour le monde!, model: code-davinci-002, token: 7            |
-| text: Bonjour le monde!, model: code-davinci-001, token: 7            | text: Bonjour le monde!, model: code-davinci-001, token: 7            |
-| text: Bonjour le monde!, model: code-cushman-002, token: 7            | text: Bonjour le monde!, model: code-cushman-002, token: 7            |
-| text: Bonjour le monde!, model: code-cushman-001, token: 7            | text: Bonjour le monde!, model: code-cushman-001, token: 7            |
-| text: Bonjour le monde!, model: davinci-codex, token: 7               | text: Bonjour le monde!, model: davinci-codex, token: 7               |
-| text: Bonjour le monde!, model: cushman-codex, token: 7               | text: Bonjour le monde!, model: cushman-codex, token: 7               |
-| text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       |
-| text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       |
-| text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      | text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      |
-| text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 | text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 |
-| text: Ciao mondo!, model: gpt-4, token: 4                             | text: Ciao mondo!, model: gpt-4, token: 4                             |
-| text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     | text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     |
-| text: Ciao mondo!, model: text-davinci-003, token: 5                  | text: Ciao mondo!, model: text-davinci-003, token: 5                  |
-| text: Ciao mondo!, model: text-davinci-002, token: 5                  | text: Ciao mondo!, model: text-davinci-002, token: 5                  |
-| text: Ciao mondo!, model: text-davinci-001, token: 5                  | text: Ciao mondo!, model: text-davinci-001, token: 5                  |
-| text: Ciao mondo!, model: text-curie-001, token: 5                    | text: Ciao mondo!, model: text-curie-001, token: 5                    |
-| text: Ciao mondo!, model: text-babbage-001, token: 5                  | text: Ciao mondo!, model: text-babbage-001, token: 5                  |
-| text: Ciao mondo!, model: text-ada-001, token: 5                      | text: Ciao mondo!, model: text-ada-001, token: 5                      |
-| text: Ciao mondo!, model: davinci, token: 5                           | text: Ciao mondo!, model: davinci, token: 5                           |
-| text: Ciao mondo!, model: curie, token: 5                             | text: Ciao mondo!, model: curie, token: 5                             |
-| text: Ciao mondo!, model: babbage, token: 5                           | text: Ciao mondo!, model: babbage, token: 5                           |
-| text: Ciao mondo!, model: ada, token: 5                               | text: Ciao mondo!, model: ada, token: 5                               |
-| text: Ciao mondo!, model: code-davinci-002, token: 5                  | text: Ciao mondo!, model: code-davinci-002, token: 5                  |
-| text: Ciao mondo!, model: code-davinci-001, token: 5                  | text: Ciao mondo!, model: code-davinci-001, token: 5                  |
-| text: Ciao mondo!, model: code-cushman-002, token: 5                  | text: Ciao mondo!, model: code-cushman-002, token: 5                  |
-| text: Ciao mondo!, model: code-cushman-001, token: 5                  | text: Ciao mondo!, model: code-cushman-001, token: 5                  |
-| text: Ciao mondo!, model: davinci-codex, token: 5                     | text: Ciao mondo!, model: davinci-codex, token: 5                     |
-| text: Ciao mondo!, model: cushman-codex, token: 5                     | text: Ciao mondo!, model: cushman-codex, token: 5                     |
-| text: Ciao mondo!, model: text-davinci-edit-001, token: 5             | text: Ciao mondo!, model: text-davinci-edit-001, token: 5             |
-| text: Ciao mondo!, model: code-davinci-edit-001, token: 5             | text: Ciao mondo!, model: code-davinci-edit-001, token: 5             |
-| text: Ciao mondo!, model: text-embedding-ada-002, token: 4            | text: Ciao mondo!, model: text-embedding-ada-002, token: 4            |
-| text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       | text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       |
-| text: Hej världen!, model: gpt-4, token: 7                            | text: Hej världen!, model: gpt-4, token: 7                            |
-| text: Hej världen!, model: gpt-3.5-turbo, token: 7                    | text: Hej världen!, model: gpt-3.5-turbo, token: 7                    |
-| text: Hej världen!, model: text-davinci-003, token: 8                 | text: Hej världen!, model: text-davinci-003, token: 8                 |
-| text: Hej världen!, model: text-davinci-002, token: 8                 | text: Hej världen!, model: text-davinci-002, token: 8                 |
-| text: Hej världen!, model: text-davinci-001, token: 8                 | text: Hej världen!, model: text-davinci-001, token: 8                 |
-| text: Hej världen!, model: text-curie-001, token: 8                   | text: Hej världen!, model: text-curie-001, token: 8                   |
-| text: Hej världen!, model: text-babbage-001, token: 8                 | text: Hej världen!, model: text-babbage-001, token: 8                 |
-| text: Hej världen!, model: text-ada-001, token: 8                     | text: Hej världen!, model: text-ada-001, token: 8                     |
-| text: Hej världen!, model: davinci, token: 8                          | text: Hej världen!, model: davinci, token: 8                          |
-| text: Hej världen!, model: curie, token: 8                            | text: Hej världen!, model: curie, token: 8                            |
-| text: Hej världen!, model: babbage, token: 8                          | text: Hej världen!, model: babbage, token: 8                          |
-| text: Hej världen!, model: ada, token: 8                              | text: Hej världen!, model: ada, token: 8                              |
-| text: Hej världen!, model: code-davinci-002, token: 8                 | text: Hej världen!, model: code-davinci-002, token: 8                 |
-| text: Hej världen!, model: code-davinci-001, token: 8                 | text: Hej världen!, model: code-davinci-001, token: 8                 |
-| text: Hej världen!, model: code-cushman-002, token: 8                 | text: Hej världen!, model: code-cushman-002, token: 8                 |
-| text: Hej världen!, model: code-cushman-001, token: 8                 | text: Hej världen!, model: code-cushman-001, token: 8                 |
-| text: Hej världen!, model: davinci-codex, token: 8                    | text: Hej världen!, model: davinci-codex, token: 8                    |
-| text: Hej världen!, model: cushman-codex, token: 8                    | text: Hej världen!, model: cushman-codex, token: 8                    |
-| text: Hej världen!, model: text-davinci-edit-001, token: 8            | text: Hej världen!, model: text-davinci-edit-001, token: 8            |
-| text: Hej världen!, model: code-davinci-edit-001, token: 8            | text: Hej världen!, model: code-davinci-edit-001, token: 8            |
-| text: Hej världen!, model: text-embedding-ada-002, token: 7           | text: Hej världen!, model: text-embedding-ada-002, token: 7           |
-| text: Hej världen!, model: text-similarity-davinci-001, token: 8      | text: Hej världen!, model: text-similarity-davinci-001, token: 8      |
-| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
-| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
-| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
-| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
-| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
-| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
-| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
-| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
-| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
-| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
-| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
-| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
-| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
-| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
-| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
-| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
-| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
-| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
-| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
-| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
-| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
-| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
-| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
-| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
-| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
-| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
-| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
-| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
-| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
-| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
-| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
-| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
-| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
-| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
-| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
-| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
-| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
-| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
-| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
-| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
-| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
-| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
-| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
-| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
-| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
-| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
-| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
-| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
-| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
-| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
-| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
-| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
-| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
-| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
-| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
-| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
-| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
-| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
-| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
-| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
-| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
-| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
-| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
-| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
-| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
-| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
-| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
-| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
-| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
-| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
-| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
-| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
-| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
-| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
-| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
-| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
-| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |
 
+
+# Benchmark
+> you can run benchmark in [test](./test) folder
+
+## Benchmark result
+| name        | time/op | os         | cpu      | text                             | times  |
+| ----------- | ------- | ---------- | -------- | -------------------------------- | ------ |
+| tiktoken-go | 8795ns  | macOS 13.2 | Apple M1 | [UDHR](https://unicode.org/udhr) | 100000 |
+| tiktoken    | 8838ns  | macOS 13.2 | Apple M1 | [UDHR](https://unicode.org/udhr) | 100000 |
+
+It looks like the performance is almost the same.   
+
+Maybe the difference is due to the difference in the performance of the machine.
+
+Or maybe my benchmark method is not appropriate.  
+
+If you have better benchmark method or if you want add your benchmark result, please feel free to submit a PR.
 
 # License
 [MIT](./LICENSE)

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -31,21 +31,23 @@ import (
     "github.com/pkoukk/tiktoken-go"
 )
 
-func main() (num_tokens int) {
-    text = "Hello, world!"
-    encoding = "r50k_base"
+func main()  {
+	text := "Hello, world!"
+	encoding := "cl100k_base"
 
 	tke, err := tiktoken.GetEncoding(encoding)
 	if err != nil {
-		err = fmt.Errorf("GetEncoding: %v", err)
+		err = fmt.Errorf("getEncoding: %v", err)
 		return
 	}
 
-    // encode
+	// encode
 	token := tke.Encode(text, nil, nil)
 
-    // num_tokens
-    num_tokens = len(token)
+	//tokens
+	fmt.Println((token))
+	// num_tokens
+	fmt.Println(len(token))
 }
 ```
 
@@ -59,21 +61,23 @@ import (
     "github.com/pkoukk/tiktoken-go"
 )
 
-func main() (num_tokens int) {
-    text = "Hello, world!"
-    encoding = "davinci"
+func main()  {
+	text := "Hello, world!"
+	encoding := "gpt-3.5-turbo"
 
-   tkm, err := tiktoken.EncodingForModel(model)
+	tkm, err := tiktoken.EncodingForModel(encoding)
 	if err != nil {
-		err = fmt.Errorf(": %v", err)
+		err = fmt.Errorf("getEncoding: %v", err)
 		return
 	}
 
-	 // encode
-	token := tke.Encode(text, nil, nil)
+	// encode
+	token := tkm.Encode(text, nil, nil)
 
-    // num_tokens
-    num_tokens = len(token)
+	// tokens
+	fmt.Println(token)
+	// num_tokens
+	fmt.Println(len(token))
 }
 ```
 
@@ -120,6 +124,7 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 		num_tokens += tokens_per_message
 		num_tokens += len(tkm.Encode(message.Content, nil, nil))
 		num_tokens += len(tkm.Encode(message.Role, nil, nil))
+		num_tokens += len(tkm.Encode(message.Name,nil,nil))
 		if message.Name != "" {
 			num_tokens += tokens_per_name
 		}
@@ -135,7 +140,6 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
  | `cl100k_base`           | `gpt-4`, `gpt-3.5-turbo`, `text-embedding-ada-002`   |
  | `p50k_base`             | Codex models, `text-davinci-002`, `text-davinci-003` |
  | `r50k_base` (or `gpt2`) | GPT-3 models like `davinci`                          |
-
 
 
 # available models
@@ -179,366 +183,25 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 # 与官方 [tiktoken](https://github.com/openai/tiktoken) 的对比
 
 ## get token by encoding
-
-| python tiktoken                                          | golang tiktoken-go                                       |
-| :------------------------------------------------------- | :------------------------------------------------------- |
-| text: hallo world!, encoding: cl100k_base, token: 4      | text: hallo world!, encoding: cl100k_base, token: 4      |
-| text: hallo world!, encoding: p50k_base, token: 4        | text: hallo world!, encoding: p50k_base, token: 4        |
-| text: hallo world!, encoding: r50k_base, token: 4        | text: hallo world!, encoding: r50k_base, token: 4        |
-| text: 你好世界！, encoding: cl100k_base, token: 6        | text: 你好世界！, encoding: cl100k_base, token: 6        |
-| text: 你好世界！, encoding: p50k_base, token: 11         | text: 你好世界！, encoding: p50k_base, token: 11         |
-| text: 你好世界！, encoding: r50k_base, token: 11         | text: 你好世界！, encoding: r50k_base, token: 11         |
-| text: こんにちは世界！, encoding: cl100k_base, token: 5  | text: こんにちは世界！, encoding: cl100k_base, token: 5  |
-| text: こんにちは世界！, encoding: p50k_base, token: 13   | text: こんにちは世界！, encoding: p50k_base, token: 13   |
-| text: こんにちは世界！, encoding: r50k_base, token: 13   | text: こんにちは世界！, encoding: r50k_base, token: 13   |
-| text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 | text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 |
-| text: 안녕하세요 세계!, encoding: p50k_base, token: 21   | text: 안녕하세요 세계!, encoding: p50k_base, token: 21   |
-| text: 안녕하세요 세계!, encoding: r50k_base, token: 21   | text: 안녕하세요 세계!, encoding: r50k_base, token: 21   |
-| text: Привет мир!, encoding: cl100k_base, token: 6       | text: Привет мир!, encoding: cl100k_base, token: 6       |
-| text: Привет мир!, encoding: p50k_base, token: 12        | text: Привет мир!, encoding: p50k_base, token: 12        |
-| text: Привет мир!, encoding: r50k_base, token: 12        | text: Привет мир!, encoding: r50k_base, token: 12        |
-| text: ¡Hola mundo!, encoding: cl100k_base, token: 4      | text: ¡Hola mundo!, encoding: cl100k_base, token: 4      |
-| text: ¡Hola mundo!, encoding: p50k_base, token: 7        | text: ¡Hola mundo!, encoding: p50k_base, token: 7        |
-| text: ¡Hola mundo!, encoding: r50k_base, token: 7        | text: ¡Hola mundo!, encoding: r50k_base, token: 7        |
-| text: Hallo Welt!, encoding: cl100k_base, token: 3       | text: Hallo Welt!, encoding: cl100k_base, token: 3       |
-| text: Hallo Welt!, encoding: p50k_base, token: 5         | text: Hallo Welt!, encoding: p50k_base, token: 5         |
-| text: Hallo Welt!, encoding: r50k_base, token: 5         | text: Hallo Welt!, encoding: r50k_base, token: 5         |
-| text: Bonjour le monde!, encoding: cl100k_base, token: 4 | text: Bonjour le monde!, encoding: cl100k_base, token: 4 |
-| text: Bonjour le monde!, encoding: p50k_base, token: 7   | text: Bonjour le monde!, encoding: p50k_base, token: 7   |
-| text: Bonjour le monde!, encoding: r50k_base, token: 7   | text: Bonjour le monde!, encoding: r50k_base, token: 7   |
-| text: Ciao mondo!, encoding: cl100k_base, token: 4       | text: Ciao mondo!, encoding: cl100k_base, token: 4       |
-| text: Ciao mondo!, encoding: p50k_base, token: 5         | text: Ciao mondo!, encoding: p50k_base, token: 5         |
-| text: Ciao mondo!, encoding: r50k_base, token: 5         | text: Ciao mondo!, encoding: r50k_base, token: 5         |
-| text: Hej världen!, encoding: cl100k_base, token: 7      | text: Hej världen!, encoding: cl100k_base, token: 7      |
-| text: Hej världen!, encoding: p50k_base, token: 8        | text: Hej världen!, encoding: p50k_base, token: 8        |
-| text: Hej världen!, encoding: r50k_base, token: 8        | text: Hej världen!, encoding: r50k_base, token: 8        |
-| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
-| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
-| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
-| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
-| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
-| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
-| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
-| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
-| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
-| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
-| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
-| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
-
+[测试结果](./doc/test_result.md#encoding-test-result)
 
 ## get token by model  
+[测试结果](./doc/test_result.md#model-test-result)
 
-| python tiktoken                                                       | golang tiktoken-go                                                    |
-| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| text: hallo world!, model: gpt-4, token: 4                            | text: hallo world!, model: gpt-4, token: 4                            |
-| text: hallo world!, model: gpt-3.5-turbo, token: 4                    | text: hallo world!, model: gpt-3.5-turbo, token: 4                    |
-| text: hallo world!, model: text-davinci-003, token: 4                 | text: hallo world!, model: text-davinci-003, token: 4                 |
-| text: hallo world!, model: text-davinci-002, token: 4                 | text: hallo world!, model: text-davinci-002, token: 4                 |
-| text: hallo world!, model: text-davinci-001, token: 4                 | text: hallo world!, model: text-davinci-001, token: 4                 |
-| text: hallo world!, model: text-curie-001, token: 4                   | text: hallo world!, model: text-curie-001, token: 4                   |
-| text: hallo world!, model: text-babbage-001, token: 4                 | text: hallo world!, model: text-babbage-001, token: 4                 |
-| text: hallo world!, model: text-ada-001, token: 4                     | text: hallo world!, model: text-ada-001, token: 4                     |
-| text: hallo world!, model: davinci, token: 4                          | text: hallo world!, model: davinci, token: 4                          |
-| text: hallo world!, model: curie, token: 4                            | text: hallo world!, model: curie, token: 4                            |
-| text: hallo world!, model: babbage, token: 4                          | text: hallo world!, model: babbage, token: 4                          |
-| text: hallo world!, model: ada, token: 4                              | text: hallo world!, model: ada, token: 4                              |
-| text: hallo world!, model: code-davinci-002, token: 4                 | text: hallo world!, model: code-davinci-002, token: 4                 |
-| text: hallo world!, model: code-davinci-001, token: 4                 | text: hallo world!, model: code-davinci-001, token: 4                 |
-| text: hallo world!, model: code-cushman-002, token: 4                 | text: hallo world!, model: code-cushman-002, token: 4                 |
-| text: hallo world!, model: code-cushman-001, token: 4                 | text: hallo world!, model: code-cushman-001, token: 4                 |
-| text: hallo world!, model: davinci-codex, token: 4                    | text: hallo world!, model: davinci-codex, token: 4                    |
-| text: hallo world!, model: cushman-codex, token: 4                    | text: hallo world!, model: cushman-codex, token: 4                    |
-| text: hallo world!, model: text-davinci-edit-001, token: 4            | text: hallo world!, model: text-davinci-edit-001, token: 4            |
-| text: hallo world!, model: code-davinci-edit-001, token: 4            | text: hallo world!, model: code-davinci-edit-001, token: 4            |
-| text: hallo world!, model: text-embedding-ada-002, token: 4           | text: hallo world!, model: text-embedding-ada-002, token: 4           |
-| text: hallo world!, model: text-similarity-davinci-001, token: 4      | text: hallo world!, model: text-similarity-davinci-001, token: 4      |
-| text: 你好世界！, model: gpt-4, token: 6                              | text: 你好世界！, model: gpt-4, token: 6                              |
-| text: 你好世界！, model: gpt-3.5-turbo, token: 6                      | text: 你好世界！, model: gpt-3.5-turbo, token: 6                      |
-| text: 你好世界！, model: text-davinci-003, token: 11                  | text: 你好世界！, model: text-davinci-003, token: 11                  |
-| text: 你好世界！, model: text-davinci-002, token: 11                  | text: 你好世界！, model: text-davinci-002, token: 11                  |
-| text: 你好世界！, model: text-davinci-001, token: 11                  | text: 你好世界！, model: text-davinci-001, token: 11                  |
-| text: 你好世界！, model: text-curie-001, token: 11                    | text: 你好世界！, model: text-curie-001, token: 11                    |
-| text: 你好世界！, model: text-babbage-001, token: 11                  | text: 你好世界！, model: text-babbage-001, token: 11                  |
-| text: 你好世界！, model: text-ada-001, token: 11                      | text: 你好世界！, model: text-ada-001, token: 11                      |
-| text: 你好世界！, model: davinci, token: 11                           | text: 你好世界！, model: davinci, token: 11                           |
-| text: 你好世界！, model: curie, token: 11                             | text: 你好世界！, model: curie, token: 11                             |
-| text: 你好世界！, model: babbage, token: 11                           | text: 你好世界！, model: babbage, token: 11                           |
-| text: 你好世界！, model: ada, token: 11                               | text: 你好世界！, model: ada, token: 11                               |
-| text: 你好世界！, model: code-davinci-002, token: 11                  | text: 你好世界！, model: code-davinci-002, token: 11                  |
-| text: 你好世界！, model: code-davinci-001, token: 11                  | text: 你好世界！, model: code-davinci-001, token: 11                  |
-| text: 你好世界！, model: code-cushman-002, token: 11                  | text: 你好世界！, model: code-cushman-002, token: 11                  |
-| text: 你好世界！, model: code-cushman-001, token: 11                  | text: 你好世界！, model: code-cushman-001, token: 11                  |
-| text: 你好世界！, model: davinci-codex, token: 11                     | text: 你好世界！, model: davinci-codex, token: 11                     |
-| text: 你好世界！, model: cushman-codex, token: 11                     | text: 你好世界！, model: cushman-codex, token: 11                     |
-| text: 你好世界！, model: text-davinci-edit-001, token: 11             | text: 你好世界！, model: text-davinci-edit-001, token: 11             |
-| text: 你好世界！, model: code-davinci-edit-001, token: 11             | text: 你好世界！, model: code-davinci-edit-001, token: 11             |
-| text: 你好世界！, model: text-embedding-ada-002, token: 6             | text: 你好世界！, model: text-embedding-ada-002, token: 6             |
-| text: 你好世界！, model: text-similarity-davinci-001, token: 11       | text: 你好世界！, model: text-similarity-davinci-001, token: 11       |
-| text: こんにちは世界！, model: gpt-4, token: 5                        | text: こんにちは世界！, model: gpt-4, token: 5                        |
-| text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                | text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                |
-| text: こんにちは世界！, model: text-davinci-003, token: 13            | text: こんにちは世界！, model: text-davinci-003, token: 13            |
-| text: こんにちは世界！, model: text-davinci-002, token: 13            | text: こんにちは世界！, model: text-davinci-002, token: 13            |
-| text: こんにちは世界！, model: text-davinci-001, token: 13            | text: こんにちは世界！, model: text-davinci-001, token: 13            |
-| text: こんにちは世界！, model: text-curie-001, token: 13              | text: こんにちは世界！, model: text-curie-001, token: 13              |
-| text: こんにちは世界！, model: text-babbage-001, token: 13            | text: こんにちは世界！, model: text-babbage-001, token: 13            |
-| text: こんにちは世界！, model: text-ada-001, token: 13                | text: こんにちは世界！, model: text-ada-001, token: 13                |
-| text: こんにちは世界！, model: davinci, token: 13                     | text: こんにちは世界！, model: davinci, token: 13                     |
-| text: こんにちは世界！, model: curie, token: 13                       | text: こんにちは世界！, model: curie, token: 13                       |
-| text: こんにちは世界！, model: babbage, token: 13                     | text: こんにちは世界！, model: babbage, token: 13                     |
-| text: こんにちは世界！, model: ada, token: 13                         | text: こんにちは世界！, model: ada, token: 13                         |
-| text: こんにちは世界！, model: code-davinci-002, token: 13            | text: こんにちは世界！, model: code-davinci-002, token: 13            |
-| text: こんにちは世界！, model: code-davinci-001, token: 13            | text: こんにちは世界！, model: code-davinci-001, token: 13            |
-| text: こんにちは世界！, model: code-cushman-002, token: 13            | text: こんにちは世界！, model: code-cushman-002, token: 13            |
-| text: こんにちは世界！, model: code-cushman-001, token: 13            | text: こんにちは世界！, model: code-cushman-001, token: 13            |
-| text: こんにちは世界！, model: davinci-codex, token: 13               | text: こんにちは世界！, model: davinci-codex, token: 13               |
-| text: こんにちは世界！, model: cushman-codex, token: 13               | text: こんにちは世界！, model: cushman-codex, token: 13               |
-| text: こんにちは世界！, model: text-davinci-edit-001, token: 13       | text: こんにちは世界！, model: text-davinci-edit-001, token: 13       |
-| text: こんにちは世界！, model: code-davinci-edit-001, token: 13       | text: こんにちは世界！, model: code-davinci-edit-001, token: 13       |
-| text: こんにちは世界！, model: text-embedding-ada-002, token: 5       | text: こんにちは世界！, model: text-embedding-ada-002, token: 5       |
-| text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 | text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 |
-| text: 안녕하세요 세계!, model: gpt-4, token: 10                       | text: 안녕하세요 세계!, model: gpt-4, token: 10                       |
-| text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               | text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               |
-| text: 안녕하세요 세계!, model: text-davinci-003, token: 21            | text: 안녕하세요 세계!, model: text-davinci-003, token: 21            |
-| text: 안녕하세요 세계!, model: text-davinci-002, token: 21            | text: 안녕하세요 세계!, model: text-davinci-002, token: 21            |
-| text: 안녕하세요 세계!, model: text-davinci-001, token: 21            | text: 안녕하세요 세계!, model: text-davinci-001, token: 21            |
-| text: 안녕하세요 세계!, model: text-curie-001, token: 21              | text: 안녕하세요 세계!, model: text-curie-001, token: 21              |
-| text: 안녕하세요 세계!, model: text-babbage-001, token: 21            | text: 안녕하세요 세계!, model: text-babbage-001, token: 21            |
-| text: 안녕하세요 세계!, model: text-ada-001, token: 21                | text: 안녕하세요 세계!, model: text-ada-001, token: 21                |
-| text: 안녕하세요 세계!, model: davinci, token: 21                     | text: 안녕하세요 세계!, model: davinci, token: 21                     |
-| text: 안녕하세요 세계!, model: curie, token: 21                       | text: 안녕하세요 세계!, model: curie, token: 21                       |
-| text: 안녕하세요 세계!, model: babbage, token: 21                     | text: 안녕하세요 세계!, model: babbage, token: 21                     |
-| text: 안녕하세요 세계!, model: ada, token: 21                         | text: 안녕하세요 세계!, model: ada, token: 21                         |
-| text: 안녕하세요 세계!, model: code-davinci-002, token: 21            | text: 안녕하세요 세계!, model: code-davinci-002, token: 21            |
-| text: 안녕하세요 세계!, model: code-davinci-001, token: 21            | text: 안녕하세요 세계!, model: code-davinci-001, token: 21            |
-| text: 안녕하세요 세계!, model: code-cushman-002, token: 21            | text: 안녕하세요 세계!, model: code-cushman-002, token: 21            |
-| text: 안녕하세요 세계!, model: code-cushman-001, token: 21            | text: 안녕하세요 세계!, model: code-cushman-001, token: 21            |
-| text: 안녕하세요 세계!, model: davinci-codex, token: 21               | text: 안녕하세요 세계!, model: davinci-codex, token: 21               |
-| text: 안녕하세요 세계!, model: cushman-codex, token: 21               | text: 안녕하세요 세계!, model: cushman-codex, token: 21               |
-| text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       |
-| text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       |
-| text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      | text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      |
-| text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 | text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 |
-| text: Привет мир!, model: gpt-4, token: 6                             | text: Привет мир!, model: gpt-4, token: 6                             |
-| text: Привет мир!, model: gpt-3.5-turbo, token: 6                     | text: Привет мир!, model: gpt-3.5-turbo, token: 6                     |
-| text: Привет мир!, model: text-davinci-003, token: 12                 | text: Привет мир!, model: text-davinci-003, token: 12                 |
-| text: Привет мир!, model: text-davinci-002, token: 12                 | text: Привет мир!, model: text-davinci-002, token: 12                 |
-| text: Привет мир!, model: text-davinci-001, token: 12                 | text: Привет мир!, model: text-davinci-001, token: 12                 |
-| text: Привет мир!, model: text-curie-001, token: 12                   | text: Привет мир!, model: text-curie-001, token: 12                   |
-| text: Привет мир!, model: text-babbage-001, token: 12                 | text: Привет мир!, model: text-babbage-001, token: 12                 |
-| text: Привет мир!, model: text-ada-001, token: 12                     | text: Привет мир!, model: text-ada-001, token: 12                     |
-| text: Привет мир!, model: davinci, token: 12                          | text: Привет мир!, model: davinci, token: 12                          |
-| text: Привет мир!, model: curie, token: 12                            | text: Привет мир!, model: curie, token: 12                            |
-| text: Привет мир!, model: babbage, token: 12                          | text: Привет мир!, model: babbage, token: 12                          |
-| text: Привет мир!, model: ada, token: 12                              | text: Привет мир!, model: ada, token: 12                              |
-| text: Привет мир!, model: code-davinci-002, token: 12                 | text: Привет мир!, model: code-davinci-002, token: 12                 |
-| text: Привет мир!, model: code-davinci-001, token: 12                 | text: Привет мир!, model: code-davinci-001, token: 12                 |
-| text: Привет мир!, model: code-cushman-002, token: 12                 | text: Привет мир!, model: code-cushman-002, token: 12                 |
-| text: Привет мир!, model: code-cushman-001, token: 12                 | text: Привет мир!, model: code-cushman-001, token: 12                 |
-| text: Привет мир!, model: davinci-codex, token: 12                    | text: Привет мир!, model: davinci-codex, token: 12                    |
-| text: Привет мир!, model: cushman-codex, token: 12                    | text: Привет мир!, model: cushman-codex, token: 12                    |
-| text: Привет мир!, model: text-davinci-edit-001, token: 12            | text: Привет мир!, model: text-davinci-edit-001, token: 12            |
-| text: Привет мир!, model: code-davinci-edit-001, token: 12            | text: Привет мир!, model: code-davinci-edit-001, token: 12            |
-| text: Привет мир!, model: text-embedding-ada-002, token: 6            | text: Привет мир!, model: text-embedding-ada-002, token: 6            |
-| text: Привет мир!, model: text-similarity-davinci-001, token: 12      | text: Привет мир!, model: text-similarity-davinci-001, token: 12      |
-| text: ¡Hola mundo!, model: gpt-4, token: 4                            | text: ¡Hola mundo!, model: gpt-4, token: 4                            |
-| text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    | text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    |
-| text: ¡Hola mundo!, model: text-davinci-003, token: 7                 | text: ¡Hola mundo!, model: text-davinci-003, token: 7                 |
-| text: ¡Hola mundo!, model: text-davinci-002, token: 7                 | text: ¡Hola mundo!, model: text-davinci-002, token: 7                 |
-| text: ¡Hola mundo!, model: text-davinci-001, token: 7                 | text: ¡Hola mundo!, model: text-davinci-001, token: 7                 |
-| text: ¡Hola mundo!, model: text-curie-001, token: 7                   | text: ¡Hola mundo!, model: text-curie-001, token: 7                   |
-| text: ¡Hola mundo!, model: text-babbage-001, token: 7                 | text: ¡Hola mundo!, model: text-babbage-001, token: 7                 |
-| text: ¡Hola mundo!, model: text-ada-001, token: 7                     | text: ¡Hola mundo!, model: text-ada-001, token: 7                     |
-| text: ¡Hola mundo!, model: davinci, token: 7                          | text: ¡Hola mundo!, model: davinci, token: 7                          |
-| text: ¡Hola mundo!, model: curie, token: 7                            | text: ¡Hola mundo!, model: curie, token: 7                            |
-| text: ¡Hola mundo!, model: babbage, token: 7                          | text: ¡Hola mundo!, model: babbage, token: 7                          |
-| text: ¡Hola mundo!, model: ada, token: 7                              | text: ¡Hola mundo!, model: ada, token: 7                              |
-| text: ¡Hola mundo!, model: code-davinci-002, token: 7                 | text: ¡Hola mundo!, model: code-davinci-002, token: 7                 |
-| text: ¡Hola mundo!, model: code-davinci-001, token: 7                 | text: ¡Hola mundo!, model: code-davinci-001, token: 7                 |
-| text: ¡Hola mundo!, model: code-cushman-002, token: 7                 | text: ¡Hola mundo!, model: code-cushman-002, token: 7                 |
-| text: ¡Hola mundo!, model: code-cushman-001, token: 7                 | text: ¡Hola mundo!, model: code-cushman-001, token: 7                 |
-| text: ¡Hola mundo!, model: davinci-codex, token: 7                    | text: ¡Hola mundo!, model: davinci-codex, token: 7                    |
-| text: ¡Hola mundo!, model: cushman-codex, token: 7                    | text: ¡Hola mundo!, model: cushman-codex, token: 7                    |
-| text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            |
-| text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            |
-| text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           | text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           |
-| text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      | text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      |
-| text: Hallo Welt!, model: gpt-4, token: 3                             | text: Hallo Welt!, model: gpt-4, token: 3                             |
-| text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     | text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     |
-| text: Hallo Welt!, model: text-davinci-003, token: 5                  | text: Hallo Welt!, model: text-davinci-003, token: 5                  |
-| text: Hallo Welt!, model: text-davinci-002, token: 5                  | text: Hallo Welt!, model: text-davinci-002, token: 5                  |
-| text: Hallo Welt!, model: text-davinci-001, token: 5                  | text: Hallo Welt!, model: text-davinci-001, token: 5                  |
-| text: Hallo Welt!, model: text-curie-001, token: 5                    | text: Hallo Welt!, model: text-curie-001, token: 5                    |
-| text: Hallo Welt!, model: text-babbage-001, token: 5                  | text: Hallo Welt!, model: text-babbage-001, token: 5                  |
-| text: Hallo Welt!, model: text-ada-001, token: 5                      | text: Hallo Welt!, model: text-ada-001, token: 5                      |
-| text: Hallo Welt!, model: davinci, token: 5                           | text: Hallo Welt!, model: davinci, token: 5                           |
-| text: Hallo Welt!, model: curie, token: 5                             | text: Hallo Welt!, model: curie, token: 5                             |
-| text: Hallo Welt!, model: babbage, token: 5                           | text: Hallo Welt!, model: babbage, token: 5                           |
-| text: Hallo Welt!, model: ada, token: 5                               | text: Hallo Welt!, model: ada, token: 5                               |
-| text: Hallo Welt!, model: code-davinci-002, token: 5                  | text: Hallo Welt!, model: code-davinci-002, token: 5                  |
-| text: Hallo Welt!, model: code-davinci-001, token: 5                  | text: Hallo Welt!, model: code-davinci-001, token: 5                  |
-| text: Hallo Welt!, model: code-cushman-002, token: 5                  | text: Hallo Welt!, model: code-cushman-002, token: 5                  |
-| text: Hallo Welt!, model: code-cushman-001, token: 5                  | text: Hallo Welt!, model: code-cushman-001, token: 5                  |
-| text: Hallo Welt!, model: davinci-codex, token: 5                     | text: Hallo Welt!, model: davinci-codex, token: 5                     |
-| text: Hallo Welt!, model: cushman-codex, token: 5                     | text: Hallo Welt!, model: cushman-codex, token: 5                     |
-| text: Hallo Welt!, model: text-davinci-edit-001, token: 5             | text: Hallo Welt!, model: text-davinci-edit-001, token: 5             |
-| text: Hallo Welt!, model: code-davinci-edit-001, token: 5             | text: Hallo Welt!, model: code-davinci-edit-001, token: 5             |
-| text: Hallo Welt!, model: text-embedding-ada-002, token: 3            | text: Hallo Welt!, model: text-embedding-ada-002, token: 3            |
-| text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       | text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       |
-| text: Bonjour le monde!, model: gpt-4, token: 4                       | text: Bonjour le monde!, model: gpt-4, token: 4                       |
-| text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               | text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               |
-| text: Bonjour le monde!, model: text-davinci-003, token: 7            | text: Bonjour le monde!, model: text-davinci-003, token: 7            |
-| text: Bonjour le monde!, model: text-davinci-002, token: 7            | text: Bonjour le monde!, model: text-davinci-002, token: 7            |
-| text: Bonjour le monde!, model: text-davinci-001, token: 7            | text: Bonjour le monde!, model: text-davinci-001, token: 7            |
-| text: Bonjour le monde!, model: text-curie-001, token: 7              | text: Bonjour le monde!, model: text-curie-001, token: 7              |
-| text: Bonjour le monde!, model: text-babbage-001, token: 7            | text: Bonjour le monde!, model: text-babbage-001, token: 7            |
-| text: Bonjour le monde!, model: text-ada-001, token: 7                | text: Bonjour le monde!, model: text-ada-001, token: 7                |
-| text: Bonjour le monde!, model: davinci, token: 7                     | text: Bonjour le monde!, model: davinci, token: 7                     |
-| text: Bonjour le monde!, model: curie, token: 7                       | text: Bonjour le monde!, model: curie, token: 7                       |
-| text: Bonjour le monde!, model: babbage, token: 7                     | text: Bonjour le monde!, model: babbage, token: 7                     |
-| text: Bonjour le monde!, model: ada, token: 7                         | text: Bonjour le monde!, model: ada, token: 7                         |
-| text: Bonjour le monde!, model: code-davinci-002, token: 7            | text: Bonjour le monde!, model: code-davinci-002, token: 7            |
-| text: Bonjour le monde!, model: code-davinci-001, token: 7            | text: Bonjour le monde!, model: code-davinci-001, token: 7            |
-| text: Bonjour le monde!, model: code-cushman-002, token: 7            | text: Bonjour le monde!, model: code-cushman-002, token: 7            |
-| text: Bonjour le monde!, model: code-cushman-001, token: 7            | text: Bonjour le monde!, model: code-cushman-001, token: 7            |
-| text: Bonjour le monde!, model: davinci-codex, token: 7               | text: Bonjour le monde!, model: davinci-codex, token: 7               |
-| text: Bonjour le monde!, model: cushman-codex, token: 7               | text: Bonjour le monde!, model: cushman-codex, token: 7               |
-| text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       |
-| text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       |
-| text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      | text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      |
-| text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 | text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 |
-| text: Ciao mondo!, model: gpt-4, token: 4                             | text: Ciao mondo!, model: gpt-4, token: 4                             |
-| text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     | text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     |
-| text: Ciao mondo!, model: text-davinci-003, token: 5                  | text: Ciao mondo!, model: text-davinci-003, token: 5                  |
-| text: Ciao mondo!, model: text-davinci-002, token: 5                  | text: Ciao mondo!, model: text-davinci-002, token: 5                  |
-| text: Ciao mondo!, model: text-davinci-001, token: 5                  | text: Ciao mondo!, model: text-davinci-001, token: 5                  |
-| text: Ciao mondo!, model: text-curie-001, token: 5                    | text: Ciao mondo!, model: text-curie-001, token: 5                    |
-| text: Ciao mondo!, model: text-babbage-001, token: 5                  | text: Ciao mondo!, model: text-babbage-001, token: 5                  |
-| text: Ciao mondo!, model: text-ada-001, token: 5                      | text: Ciao mondo!, model: text-ada-001, token: 5                      |
-| text: Ciao mondo!, model: davinci, token: 5                           | text: Ciao mondo!, model: davinci, token: 5                           |
-| text: Ciao mondo!, model: curie, token: 5                             | text: Ciao mondo!, model: curie, token: 5                             |
-| text: Ciao mondo!, model: babbage, token: 5                           | text: Ciao mondo!, model: babbage, token: 5                           |
-| text: Ciao mondo!, model: ada, token: 5                               | text: Ciao mondo!, model: ada, token: 5                               |
-| text: Ciao mondo!, model: code-davinci-002, token: 5                  | text: Ciao mondo!, model: code-davinci-002, token: 5                  |
-| text: Ciao mondo!, model: code-davinci-001, token: 5                  | text: Ciao mondo!, model: code-davinci-001, token: 5                  |
-| text: Ciao mondo!, model: code-cushman-002, token: 5                  | text: Ciao mondo!, model: code-cushman-002, token: 5                  |
-| text: Ciao mondo!, model: code-cushman-001, token: 5                  | text: Ciao mondo!, model: code-cushman-001, token: 5                  |
-| text: Ciao mondo!, model: davinci-codex, token: 5                     | text: Ciao mondo!, model: davinci-codex, token: 5                     |
-| text: Ciao mondo!, model: cushman-codex, token: 5                     | text: Ciao mondo!, model: cushman-codex, token: 5                     |
-| text: Ciao mondo!, model: text-davinci-edit-001, token: 5             | text: Ciao mondo!, model: text-davinci-edit-001, token: 5             |
-| text: Ciao mondo!, model: code-davinci-edit-001, token: 5             | text: Ciao mondo!, model: code-davinci-edit-001, token: 5             |
-| text: Ciao mondo!, model: text-embedding-ada-002, token: 4            | text: Ciao mondo!, model: text-embedding-ada-002, token: 4            |
-| text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       | text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       |
-| text: Hej världen!, model: gpt-4, token: 7                            | text: Hej världen!, model: gpt-4, token: 7                            |
-| text: Hej världen!, model: gpt-3.5-turbo, token: 7                    | text: Hej världen!, model: gpt-3.5-turbo, token: 7                    |
-| text: Hej världen!, model: text-davinci-003, token: 8                 | text: Hej världen!, model: text-davinci-003, token: 8                 |
-| text: Hej världen!, model: text-davinci-002, token: 8                 | text: Hej världen!, model: text-davinci-002, token: 8                 |
-| text: Hej världen!, model: text-davinci-001, token: 8                 | text: Hej världen!, model: text-davinci-001, token: 8                 |
-| text: Hej världen!, model: text-curie-001, token: 8                   | text: Hej världen!, model: text-curie-001, token: 8                   |
-| text: Hej världen!, model: text-babbage-001, token: 8                 | text: Hej världen!, model: text-babbage-001, token: 8                 |
-| text: Hej världen!, model: text-ada-001, token: 8                     | text: Hej världen!, model: text-ada-001, token: 8                     |
-| text: Hej världen!, model: davinci, token: 8                          | text: Hej världen!, model: davinci, token: 8                          |
-| text: Hej världen!, model: curie, token: 8                            | text: Hej världen!, model: curie, token: 8                            |
-| text: Hej världen!, model: babbage, token: 8                          | text: Hej världen!, model: babbage, token: 8                          |
-| text: Hej världen!, model: ada, token: 8                              | text: Hej världen!, model: ada, token: 8                              |
-| text: Hej världen!, model: code-davinci-002, token: 8                 | text: Hej världen!, model: code-davinci-002, token: 8                 |
-| text: Hej världen!, model: code-davinci-001, token: 8                 | text: Hej världen!, model: code-davinci-001, token: 8                 |
-| text: Hej världen!, model: code-cushman-002, token: 8                 | text: Hej världen!, model: code-cushman-002, token: 8                 |
-| text: Hej världen!, model: code-cushman-001, token: 8                 | text: Hej världen!, model: code-cushman-001, token: 8                 |
-| text: Hej världen!, model: davinci-codex, token: 8                    | text: Hej världen!, model: davinci-codex, token: 8                    |
-| text: Hej världen!, model: cushman-codex, token: 8                    | text: Hej världen!, model: cushman-codex, token: 8                    |
-| text: Hej världen!, model: text-davinci-edit-001, token: 8            | text: Hej världen!, model: text-davinci-edit-001, token: 8            |
-| text: Hej världen!, model: code-davinci-edit-001, token: 8            | text: Hej världen!, model: code-davinci-edit-001, token: 8            |
-| text: Hej världen!, model: text-embedding-ada-002, token: 7           | text: Hej världen!, model: text-embedding-ada-002, token: 7           |
-| text: Hej världen!, model: text-similarity-davinci-001, token: 8      | text: Hej världen!, model: text-similarity-davinci-001, token: 8      |
-| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
-| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
-| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
-| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
-| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
-| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
-| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
-| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
-| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
-| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
-| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
-| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
-| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
-| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
-| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
-| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
-| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
-| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
-| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
-| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
-| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
-| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
-| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
-| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
-| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
-| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
-| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
-| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
-| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
-| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
-| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
-| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
-| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
-| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
-| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
-| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
-| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
-| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
-| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
-| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
-| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
-| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
-| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
-| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
-| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
-| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
-| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
-| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
-| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
-| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
-| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
-| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
-| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
-| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
-| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
-| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
-| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
-| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
-| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
-| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
-| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
-| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
-| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
-| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
-| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
-| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
-| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
-| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
-| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
-| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
-| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
-| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
-| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
-| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
-| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
-| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
-| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
-| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
-| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |
+# Benchmark
+> 你可以使用 [test](./test) 目录下的文件执行基准测试。 
 
+## Benchmark result
+| name        | time/op | os         | cpu      | text                             | times  |
+| ----------- | ------- | ---------- | -------- | -------------------------------- | ------ |
+| tiktoken-go | 8795ns  | macOS 13.2 | Apple M1 | [UDHR](https://unicode.org/udhr) | 100000 |
+| tiktoken    | 8838ns  | macOS 13.2 | Apple M1 | [UDHR](https://unicode.org/udhr) | 100000 |
+
+看上去tiktoken-go的性能基本与原tiktoken一致。  
+
+也许在不同的机器上的测试结果会有所不同。也可能是我的测试方法并不恰当。
+
+如果你有更好的测试方法，或者说你想添加在你机器上的测试结果，欢迎提PR。
 
 # License
 [MIT](./LICENSE)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,43 @@
+package tiktoken
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+const TEST_FILE = "test/test.txt"
+
+func ReadTestFile() ([]byte, error) {
+	// open and read TEST_FILE
+	return ioutil.ReadFile(TEST_FILE)
+}
+
+func BenchmarkEncoding(b *testing.B) {
+	fileContent, err := ReadTestFile()
+	if err != nil {
+		panic(err)
+	}
+
+	tkm, err := EncodingForModel("gpt-4")
+	if err != nil {
+		panic(err)
+	}
+
+	text := string(fileContent)
+
+	for ordersOfMagnitude := 0; ordersOfMagnitude < 4; ordersOfMagnitude++ {
+		// do actual encoding
+		fmt.Printf("Encoding %d bytes\n", len(text))
+		tkm.Encode(text, nil, nil)
+
+		stringBuilder := strings.Builder{}
+		for i := 0; i < 10; i++ {
+			stringBuilder.WriteString(text)
+		}
+
+		text = stringBuilder.String()
+	}
+
+}

--- a/doc/test_result.md
+++ b/doc/test_result.md
@@ -1,0 +1,357 @@
+# Encoding Test Result
+| python tiktoken                                          | golang tiktoken-go                                       |
+| :------------------------------------------------------- | :------------------------------------------------------- |
+| text: hallo world!, encoding: cl100k_base, token: 4      | text: hallo world!, encoding: cl100k_base, token: 4      |
+| text: hallo world!, encoding: p50k_base, token: 4        | text: hallo world!, encoding: p50k_base, token: 4        |
+| text: hallo world!, encoding: r50k_base, token: 4        | text: hallo world!, encoding: r50k_base, token: 4        |
+| text: 你好世界！, encoding: cl100k_base, token: 6        | text: 你好世界！, encoding: cl100k_base, token: 6        |
+| text: 你好世界！, encoding: p50k_base, token: 11         | text: 你好世界！, encoding: p50k_base, token: 11         |
+| text: 你好世界！, encoding: r50k_base, token: 11         | text: 你好世界！, encoding: r50k_base, token: 11         |
+| text: こんにちは世界！, encoding: cl100k_base, token: 5  | text: こんにちは世界！, encoding: cl100k_base, token: 5  |
+| text: こんにちは世界！, encoding: p50k_base, token: 13   | text: こんにちは世界！, encoding: p50k_base, token: 13   |
+| text: こんにちは世界！, encoding: r50k_base, token: 13   | text: こんにちは世界！, encoding: r50k_base, token: 13   |
+| text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 | text: 안녕하세요 세계!, encoding: cl100k_base, token: 10 |
+| text: 안녕하세요 세계!, encoding: p50k_base, token: 21   | text: 안녕하세요 세계!, encoding: p50k_base, token: 21   |
+| text: 안녕하세요 세계!, encoding: r50k_base, token: 21   | text: 안녕하세요 세계!, encoding: r50k_base, token: 21   |
+| text: Привет мир!, encoding: cl100k_base, token: 6       | text: Привет мир!, encoding: cl100k_base, token: 6       |
+| text: Привет мир!, encoding: p50k_base, token: 12        | text: Привет мир!, encoding: p50k_base, token: 12        |
+| text: Привет мир!, encoding: r50k_base, token: 12        | text: Привет мир!, encoding: r50k_base, token: 12        |
+| text: ¡Hola mundo!, encoding: cl100k_base, token: 4      | text: ¡Hola mundo!, encoding: cl100k_base, token: 4      |
+| text: ¡Hola mundo!, encoding: p50k_base, token: 7        | text: ¡Hola mundo!, encoding: p50k_base, token: 7        |
+| text: ¡Hola mundo!, encoding: r50k_base, token: 7        | text: ¡Hola mundo!, encoding: r50k_base, token: 7        |
+| text: Hallo Welt!, encoding: cl100k_base, token: 3       | text: Hallo Welt!, encoding: cl100k_base, token: 3       |
+| text: Hallo Welt!, encoding: p50k_base, token: 5         | text: Hallo Welt!, encoding: p50k_base, token: 5         |
+| text: Hallo Welt!, encoding: r50k_base, token: 5         | text: Hallo Welt!, encoding: r50k_base, token: 5         |
+| text: Bonjour le monde!, encoding: cl100k_base, token: 4 | text: Bonjour le monde!, encoding: cl100k_base, token: 4 |
+| text: Bonjour le monde!, encoding: p50k_base, token: 7   | text: Bonjour le monde!, encoding: p50k_base, token: 7   |
+| text: Bonjour le monde!, encoding: r50k_base, token: 7   | text: Bonjour le monde!, encoding: r50k_base, token: 7   |
+| text: Ciao mondo!, encoding: cl100k_base, token: 4       | text: Ciao mondo!, encoding: cl100k_base, token: 4       |
+| text: Ciao mondo!, encoding: p50k_base, token: 5         | text: Ciao mondo!, encoding: p50k_base, token: 5         |
+| text: Ciao mondo!, encoding: r50k_base, token: 5         | text: Ciao mondo!, encoding: r50k_base, token: 5         |
+| text: Hej världen!, encoding: cl100k_base, token: 7      | text: Hej världen!, encoding: cl100k_base, token: 7      |
+| text: Hej världen!, encoding: p50k_base, token: 8        | text: Hej världen!, encoding: p50k_base, token: 8        |
+| text: Hej världen!, encoding: r50k_base, token: 8        | text: Hej världen!, encoding: r50k_base, token: 8        |
+| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
+| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
+| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
+| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
+| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
+| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
+| text: Hallo wereld!, encoding: cl100k_base, token: 3     | text: Hallo wereld!, encoding: cl100k_base, token: 3     |
+| text: Hallo wereld!, encoding: p50k_base, token: 5       | text: Hallo wereld!, encoding: p50k_base, token: 5       |
+| text: Hallo wereld!, encoding: r50k_base, token: 5       | text: Hallo wereld!, encoding: r50k_base, token: 5       |
+| text: Hallo verden!, encoding: cl100k_base, token: 4     | text: Hallo verden!, encoding: cl100k_base, token: 4     |
+| text: Hallo verden!, encoding: p50k_base, token: 5       | text: Hallo verden!, encoding: p50k_base, token: 5       |
+| text: Hallo verden!, encoding: r50k_base, token: 5       | text: Hallo verden!, encoding: r50k_base, token: 5       |
+
+# Model Test Result
+| python tiktoken                                                       | golang tiktoken-go                                                    |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| text: hallo world!, model: gpt-4, token: 4                            | text: hallo world!, model: gpt-4, token: 4                            |
+| text: hallo world!, model: gpt-3.5-turbo, token: 4                    | text: hallo world!, model: gpt-3.5-turbo, token: 4                    |
+| text: hallo world!, model: text-davinci-003, token: 4                 | text: hallo world!, model: text-davinci-003, token: 4                 |
+| text: hallo world!, model: text-davinci-002, token: 4                 | text: hallo world!, model: text-davinci-002, token: 4                 |
+| text: hallo world!, model: text-davinci-001, token: 4                 | text: hallo world!, model: text-davinci-001, token: 4                 |
+| text: hallo world!, model: text-curie-001, token: 4                   | text: hallo world!, model: text-curie-001, token: 4                   |
+| text: hallo world!, model: text-babbage-001, token: 4                 | text: hallo world!, model: text-babbage-001, token: 4                 |
+| text: hallo world!, model: text-ada-001, token: 4                     | text: hallo world!, model: text-ada-001, token: 4                     |
+| text: hallo world!, model: davinci, token: 4                          | text: hallo world!, model: davinci, token: 4                          |
+| text: hallo world!, model: curie, token: 4                            | text: hallo world!, model: curie, token: 4                            |
+| text: hallo world!, model: babbage, token: 4                          | text: hallo world!, model: babbage, token: 4                          |
+| text: hallo world!, model: ada, token: 4                              | text: hallo world!, model: ada, token: 4                              |
+| text: hallo world!, model: code-davinci-002, token: 4                 | text: hallo world!, model: code-davinci-002, token: 4                 |
+| text: hallo world!, model: code-davinci-001, token: 4                 | text: hallo world!, model: code-davinci-001, token: 4                 |
+| text: hallo world!, model: code-cushman-002, token: 4                 | text: hallo world!, model: code-cushman-002, token: 4                 |
+| text: hallo world!, model: code-cushman-001, token: 4                 | text: hallo world!, model: code-cushman-001, token: 4                 |
+| text: hallo world!, model: davinci-codex, token: 4                    | text: hallo world!, model: davinci-codex, token: 4                    |
+| text: hallo world!, model: cushman-codex, token: 4                    | text: hallo world!, model: cushman-codex, token: 4                    |
+| text: hallo world!, model: text-davinci-edit-001, token: 4            | text: hallo world!, model: text-davinci-edit-001, token: 4            |
+| text: hallo world!, model: code-davinci-edit-001, token: 4            | text: hallo world!, model: code-davinci-edit-001, token: 4            |
+| text: hallo world!, model: text-embedding-ada-002, token: 4           | text: hallo world!, model: text-embedding-ada-002, token: 4           |
+| text: hallo world!, model: text-similarity-davinci-001, token: 4      | text: hallo world!, model: text-similarity-davinci-001, token: 4      |
+| text: 你好世界！, model: gpt-4, token: 6                              | text: 你好世界！, model: gpt-4, token: 6                              |
+| text: 你好世界！, model: gpt-3.5-turbo, token: 6                      | text: 你好世界！, model: gpt-3.5-turbo, token: 6                      |
+| text: 你好世界！, model: text-davinci-003, token: 11                  | text: 你好世界！, model: text-davinci-003, token: 11                  |
+| text: 你好世界！, model: text-davinci-002, token: 11                  | text: 你好世界！, model: text-davinci-002, token: 11                  |
+| text: 你好世界！, model: text-davinci-001, token: 11                  | text: 你好世界！, model: text-davinci-001, token: 11                  |
+| text: 你好世界！, model: text-curie-001, token: 11                    | text: 你好世界！, model: text-curie-001, token: 11                    |
+| text: 你好世界！, model: text-babbage-001, token: 11                  | text: 你好世界！, model: text-babbage-001, token: 11                  |
+| text: 你好世界！, model: text-ada-001, token: 11                      | text: 你好世界！, model: text-ada-001, token: 11                      |
+| text: 你好世界！, model: davinci, token: 11                           | text: 你好世界！, model: davinci, token: 11                           |
+| text: 你好世界！, model: curie, token: 11                             | text: 你好世界！, model: curie, token: 11                             |
+| text: 你好世界！, model: babbage, token: 11                           | text: 你好世界！, model: babbage, token: 11                           |
+| text: 你好世界！, model: ada, token: 11                               | text: 你好世界！, model: ada, token: 11                               |
+| text: 你好世界！, model: code-davinci-002, token: 11                  | text: 你好世界！, model: code-davinci-002, token: 11                  |
+| text: 你好世界！, model: code-davinci-001, token: 11                  | text: 你好世界！, model: code-davinci-001, token: 11                  |
+| text: 你好世界！, model: code-cushman-002, token: 11                  | text: 你好世界！, model: code-cushman-002, token: 11                  |
+| text: 你好世界！, model: code-cushman-001, token: 11                  | text: 你好世界！, model: code-cushman-001, token: 11                  |
+| text: 你好世界！, model: davinci-codex, token: 11                     | text: 你好世界！, model: davinci-codex, token: 11                     |
+| text: 你好世界！, model: cushman-codex, token: 11                     | text: 你好世界！, model: cushman-codex, token: 11                     |
+| text: 你好世界！, model: text-davinci-edit-001, token: 11             | text: 你好世界！, model: text-davinci-edit-001, token: 11             |
+| text: 你好世界！, model: code-davinci-edit-001, token: 11             | text: 你好世界！, model: code-davinci-edit-001, token: 11             |
+| text: 你好世界！, model: text-embedding-ada-002, token: 6             | text: 你好世界！, model: text-embedding-ada-002, token: 6             |
+| text: 你好世界！, model: text-similarity-davinci-001, token: 11       | text: 你好世界！, model: text-similarity-davinci-001, token: 11       |
+| text: こんにちは世界！, model: gpt-4, token: 5                        | text: こんにちは世界！, model: gpt-4, token: 5                        |
+| text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                | text: こんにちは世界！, model: gpt-3.5-turbo, token: 5                |
+| text: こんにちは世界！, model: text-davinci-003, token: 13            | text: こんにちは世界！, model: text-davinci-003, token: 13            |
+| text: こんにちは世界！, model: text-davinci-002, token: 13            | text: こんにちは世界！, model: text-davinci-002, token: 13            |
+| text: こんにちは世界！, model: text-davinci-001, token: 13            | text: こんにちは世界！, model: text-davinci-001, token: 13            |
+| text: こんにちは世界！, model: text-curie-001, token: 13              | text: こんにちは世界！, model: text-curie-001, token: 13              |
+| text: こんにちは世界！, model: text-babbage-001, token: 13            | text: こんにちは世界！, model: text-babbage-001, token: 13            |
+| text: こんにちは世界！, model: text-ada-001, token: 13                | text: こんにちは世界！, model: text-ada-001, token: 13                |
+| text: こんにちは世界！, model: davinci, token: 13                     | text: こんにちは世界！, model: davinci, token: 13                     |
+| text: こんにちは世界！, model: curie, token: 13                       | text: こんにちは世界！, model: curie, token: 13                       |
+| text: こんにちは世界！, model: babbage, token: 13                     | text: こんにちは世界！, model: babbage, token: 13                     |
+| text: こんにちは世界！, model: ada, token: 13                         | text: こんにちは世界！, model: ada, token: 13                         |
+| text: こんにちは世界！, model: code-davinci-002, token: 13            | text: こんにちは世界！, model: code-davinci-002, token: 13            |
+| text: こんにちは世界！, model: code-davinci-001, token: 13            | text: こんにちは世界！, model: code-davinci-001, token: 13            |
+| text: こんにちは世界！, model: code-cushman-002, token: 13            | text: こんにちは世界！, model: code-cushman-002, token: 13            |
+| text: こんにちは世界！, model: code-cushman-001, token: 13            | text: こんにちは世界！, model: code-cushman-001, token: 13            |
+| text: こんにちは世界！, model: davinci-codex, token: 13               | text: こんにちは世界！, model: davinci-codex, token: 13               |
+| text: こんにちは世界！, model: cushman-codex, token: 13               | text: こんにちは世界！, model: cushman-codex, token: 13               |
+| text: こんにちは世界！, model: text-davinci-edit-001, token: 13       | text: こんにちは世界！, model: text-davinci-edit-001, token: 13       |
+| text: こんにちは世界！, model: code-davinci-edit-001, token: 13       | text: こんにちは世界！, model: code-davinci-edit-001, token: 13       |
+| text: こんにちは世界！, model: text-embedding-ada-002, token: 5       | text: こんにちは世界！, model: text-embedding-ada-002, token: 5       |
+| text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 | text: こんにちは世界！, model: text-similarity-davinci-001, token: 13 |
+| text: 안녕하세요 세계!, model: gpt-4, token: 10                       | text: 안녕하세요 세계!, model: gpt-4, token: 10                       |
+| text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               | text: 안녕하세요 세계!, model: gpt-3.5-turbo, token: 10               |
+| text: 안녕하세요 세계!, model: text-davinci-003, token: 21            | text: 안녕하세요 세계!, model: text-davinci-003, token: 21            |
+| text: 안녕하세요 세계!, model: text-davinci-002, token: 21            | text: 안녕하세요 세계!, model: text-davinci-002, token: 21            |
+| text: 안녕하세요 세계!, model: text-davinci-001, token: 21            | text: 안녕하세요 세계!, model: text-davinci-001, token: 21            |
+| text: 안녕하세요 세계!, model: text-curie-001, token: 21              | text: 안녕하세요 세계!, model: text-curie-001, token: 21              |
+| text: 안녕하세요 세계!, model: text-babbage-001, token: 21            | text: 안녕하세요 세계!, model: text-babbage-001, token: 21            |
+| text: 안녕하세요 세계!, model: text-ada-001, token: 21                | text: 안녕하세요 세계!, model: text-ada-001, token: 21                |
+| text: 안녕하세요 세계!, model: davinci, token: 21                     | text: 안녕하세요 세계!, model: davinci, token: 21                     |
+| text: 안녕하세요 세계!, model: curie, token: 21                       | text: 안녕하세요 세계!, model: curie, token: 21                       |
+| text: 안녕하세요 세계!, model: babbage, token: 21                     | text: 안녕하세요 세계!, model: babbage, token: 21                     |
+| text: 안녕하세요 세계!, model: ada, token: 21                         | text: 안녕하세요 세계!, model: ada, token: 21                         |
+| text: 안녕하세요 세계!, model: code-davinci-002, token: 21            | text: 안녕하세요 세계!, model: code-davinci-002, token: 21            |
+| text: 안녕하세요 세계!, model: code-davinci-001, token: 21            | text: 안녕하세요 세계!, model: code-davinci-001, token: 21            |
+| text: 안녕하세요 세계!, model: code-cushman-002, token: 21            | text: 안녕하세요 세계!, model: code-cushman-002, token: 21            |
+| text: 안녕하세요 세계!, model: code-cushman-001, token: 21            | text: 안녕하세요 세계!, model: code-cushman-001, token: 21            |
+| text: 안녕하세요 세계!, model: davinci-codex, token: 21               | text: 안녕하세요 세계!, model: davinci-codex, token: 21               |
+| text: 안녕하세요 세계!, model: cushman-codex, token: 21               | text: 안녕하세요 세계!, model: cushman-codex, token: 21               |
+| text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: text-davinci-edit-001, token: 21       |
+| text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       | text: 안녕하세요 세계!, model: code-davinci-edit-001, token: 21       |
+| text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      | text: 안녕하세요 세계!, model: text-embedding-ada-002, token: 10      |
+| text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 | text: 안녕하세요 세계!, model: text-similarity-davinci-001, token: 21 |
+| text: Привет мир!, model: gpt-4, token: 6                             | text: Привет мир!, model: gpt-4, token: 6                             |
+| text: Привет мир!, model: gpt-3.5-turbo, token: 6                     | text: Привет мир!, model: gpt-3.5-turbo, token: 6                     |
+| text: Привет мир!, model: text-davinci-003, token: 12                 | text: Привет мир!, model: text-davinci-003, token: 12                 |
+| text: Привет мир!, model: text-davinci-002, token: 12                 | text: Привет мир!, model: text-davinci-002, token: 12                 |
+| text: Привет мир!, model: text-davinci-001, token: 12                 | text: Привет мир!, model: text-davinci-001, token: 12                 |
+| text: Привет мир!, model: text-curie-001, token: 12                   | text: Привет мир!, model: text-curie-001, token: 12                   |
+| text: Привет мир!, model: text-babbage-001, token: 12                 | text: Привет мир!, model: text-babbage-001, token: 12                 |
+| text: Привет мир!, model: text-ada-001, token: 12                     | text: Привет мир!, model: text-ada-001, token: 12                     |
+| text: Привет мир!, model: davinci, token: 12                          | text: Привет мир!, model: davinci, token: 12                          |
+| text: Привет мир!, model: curie, token: 12                            | text: Привет мир!, model: curie, token: 12                            |
+| text: Привет мир!, model: babbage, token: 12                          | text: Привет мир!, model: babbage, token: 12                          |
+| text: Привет мир!, model: ada, token: 12                              | text: Привет мир!, model: ada, token: 12                              |
+| text: Привет мир!, model: code-davinci-002, token: 12                 | text: Привет мир!, model: code-davinci-002, token: 12                 |
+| text: Привет мир!, model: code-davinci-001, token: 12                 | text: Привет мир!, model: code-davinci-001, token: 12                 |
+| text: Привет мир!, model: code-cushman-002, token: 12                 | text: Привет мир!, model: code-cushman-002, token: 12                 |
+| text: Привет мир!, model: code-cushman-001, token: 12                 | text: Привет мир!, model: code-cushman-001, token: 12                 |
+| text: Привет мир!, model: davinci-codex, token: 12                    | text: Привет мир!, model: davinci-codex, token: 12                    |
+| text: Привет мир!, model: cushman-codex, token: 12                    | text: Привет мир!, model: cushman-codex, token: 12                    |
+| text: Привет мир!, model: text-davinci-edit-001, token: 12            | text: Привет мир!, model: text-davinci-edit-001, token: 12            |
+| text: Привет мир!, model: code-davinci-edit-001, token: 12            | text: Привет мир!, model: code-davinci-edit-001, token: 12            |
+| text: Привет мир!, model: text-embedding-ada-002, token: 6            | text: Привет мир!, model: text-embedding-ada-002, token: 6            |
+| text: Привет мир!, model: text-similarity-davinci-001, token: 12      | text: Привет мир!, model: text-similarity-davinci-001, token: 12      |
+| text: ¡Hola mundo!, model: gpt-4, token: 4                            | text: ¡Hola mundo!, model: gpt-4, token: 4                            |
+| text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    | text: ¡Hola mundo!, model: gpt-3.5-turbo, token: 4                    |
+| text: ¡Hola mundo!, model: text-davinci-003, token: 7                 | text: ¡Hola mundo!, model: text-davinci-003, token: 7                 |
+| text: ¡Hola mundo!, model: text-davinci-002, token: 7                 | text: ¡Hola mundo!, model: text-davinci-002, token: 7                 |
+| text: ¡Hola mundo!, model: text-davinci-001, token: 7                 | text: ¡Hola mundo!, model: text-davinci-001, token: 7                 |
+| text: ¡Hola mundo!, model: text-curie-001, token: 7                   | text: ¡Hola mundo!, model: text-curie-001, token: 7                   |
+| text: ¡Hola mundo!, model: text-babbage-001, token: 7                 | text: ¡Hola mundo!, model: text-babbage-001, token: 7                 |
+| text: ¡Hola mundo!, model: text-ada-001, token: 7                     | text: ¡Hola mundo!, model: text-ada-001, token: 7                     |
+| text: ¡Hola mundo!, model: davinci, token: 7                          | text: ¡Hola mundo!, model: davinci, token: 7                          |
+| text: ¡Hola mundo!, model: curie, token: 7                            | text: ¡Hola mundo!, model: curie, token: 7                            |
+| text: ¡Hola mundo!, model: babbage, token: 7                          | text: ¡Hola mundo!, model: babbage, token: 7                          |
+| text: ¡Hola mundo!, model: ada, token: 7                              | text: ¡Hola mundo!, model: ada, token: 7                              |
+| text: ¡Hola mundo!, model: code-davinci-002, token: 7                 | text: ¡Hola mundo!, model: code-davinci-002, token: 7                 |
+| text: ¡Hola mundo!, model: code-davinci-001, token: 7                 | text: ¡Hola mundo!, model: code-davinci-001, token: 7                 |
+| text: ¡Hola mundo!, model: code-cushman-002, token: 7                 | text: ¡Hola mundo!, model: code-cushman-002, token: 7                 |
+| text: ¡Hola mundo!, model: code-cushman-001, token: 7                 | text: ¡Hola mundo!, model: code-cushman-001, token: 7                 |
+| text: ¡Hola mundo!, model: davinci-codex, token: 7                    | text: ¡Hola mundo!, model: davinci-codex, token: 7                    |
+| text: ¡Hola mundo!, model: cushman-codex, token: 7                    | text: ¡Hola mundo!, model: cushman-codex, token: 7                    |
+| text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: text-davinci-edit-001, token: 7            |
+| text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            | text: ¡Hola mundo!, model: code-davinci-edit-001, token: 7            |
+| text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           | text: ¡Hola mundo!, model: text-embedding-ada-002, token: 4           |
+| text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      | text: ¡Hola mundo!, model: text-similarity-davinci-001, token: 7      |
+| text: Hallo Welt!, model: gpt-4, token: 3                             | text: Hallo Welt!, model: gpt-4, token: 3                             |
+| text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     | text: Hallo Welt!, model: gpt-3.5-turbo, token: 3                     |
+| text: Hallo Welt!, model: text-davinci-003, token: 5                  | text: Hallo Welt!, model: text-davinci-003, token: 5                  |
+| text: Hallo Welt!, model: text-davinci-002, token: 5                  | text: Hallo Welt!, model: text-davinci-002, token: 5                  |
+| text: Hallo Welt!, model: text-davinci-001, token: 5                  | text: Hallo Welt!, model: text-davinci-001, token: 5                  |
+| text: Hallo Welt!, model: text-curie-001, token: 5                    | text: Hallo Welt!, model: text-curie-001, token: 5                    |
+| text: Hallo Welt!, model: text-babbage-001, token: 5                  | text: Hallo Welt!, model: text-babbage-001, token: 5                  |
+| text: Hallo Welt!, model: text-ada-001, token: 5                      | text: Hallo Welt!, model: text-ada-001, token: 5                      |
+| text: Hallo Welt!, model: davinci, token: 5                           | text: Hallo Welt!, model: davinci, token: 5                           |
+| text: Hallo Welt!, model: curie, token: 5                             | text: Hallo Welt!, model: curie, token: 5                             |
+| text: Hallo Welt!, model: babbage, token: 5                           | text: Hallo Welt!, model: babbage, token: 5                           |
+| text: Hallo Welt!, model: ada, token: 5                               | text: Hallo Welt!, model: ada, token: 5                               |
+| text: Hallo Welt!, model: code-davinci-002, token: 5                  | text: Hallo Welt!, model: code-davinci-002, token: 5                  |
+| text: Hallo Welt!, model: code-davinci-001, token: 5                  | text: Hallo Welt!, model: code-davinci-001, token: 5                  |
+| text: Hallo Welt!, model: code-cushman-002, token: 5                  | text: Hallo Welt!, model: code-cushman-002, token: 5                  |
+| text: Hallo Welt!, model: code-cushman-001, token: 5                  | text: Hallo Welt!, model: code-cushman-001, token: 5                  |
+| text: Hallo Welt!, model: davinci-codex, token: 5                     | text: Hallo Welt!, model: davinci-codex, token: 5                     |
+| text: Hallo Welt!, model: cushman-codex, token: 5                     | text: Hallo Welt!, model: cushman-codex, token: 5                     |
+| text: Hallo Welt!, model: text-davinci-edit-001, token: 5             | text: Hallo Welt!, model: text-davinci-edit-001, token: 5             |
+| text: Hallo Welt!, model: code-davinci-edit-001, token: 5             | text: Hallo Welt!, model: code-davinci-edit-001, token: 5             |
+| text: Hallo Welt!, model: text-embedding-ada-002, token: 3            | text: Hallo Welt!, model: text-embedding-ada-002, token: 3            |
+| text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       | text: Hallo Welt!, model: text-similarity-davinci-001, token: 5       |
+| text: Bonjour le monde!, model: gpt-4, token: 4                       | text: Bonjour le monde!, model: gpt-4, token: 4                       |
+| text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               | text: Bonjour le monde!, model: gpt-3.5-turbo, token: 4               |
+| text: Bonjour le monde!, model: text-davinci-003, token: 7            | text: Bonjour le monde!, model: text-davinci-003, token: 7            |
+| text: Bonjour le monde!, model: text-davinci-002, token: 7            | text: Bonjour le monde!, model: text-davinci-002, token: 7            |
+| text: Bonjour le monde!, model: text-davinci-001, token: 7            | text: Bonjour le monde!, model: text-davinci-001, token: 7            |
+| text: Bonjour le monde!, model: text-curie-001, token: 7              | text: Bonjour le monde!, model: text-curie-001, token: 7              |
+| text: Bonjour le monde!, model: text-babbage-001, token: 7            | text: Bonjour le monde!, model: text-babbage-001, token: 7            |
+| text: Bonjour le monde!, model: text-ada-001, token: 7                | text: Bonjour le monde!, model: text-ada-001, token: 7                |
+| text: Bonjour le monde!, model: davinci, token: 7                     | text: Bonjour le monde!, model: davinci, token: 7                     |
+| text: Bonjour le monde!, model: curie, token: 7                       | text: Bonjour le monde!, model: curie, token: 7                       |
+| text: Bonjour le monde!, model: babbage, token: 7                     | text: Bonjour le monde!, model: babbage, token: 7                     |
+| text: Bonjour le monde!, model: ada, token: 7                         | text: Bonjour le monde!, model: ada, token: 7                         |
+| text: Bonjour le monde!, model: code-davinci-002, token: 7            | text: Bonjour le monde!, model: code-davinci-002, token: 7            |
+| text: Bonjour le monde!, model: code-davinci-001, token: 7            | text: Bonjour le monde!, model: code-davinci-001, token: 7            |
+| text: Bonjour le monde!, model: code-cushman-002, token: 7            | text: Bonjour le monde!, model: code-cushman-002, token: 7            |
+| text: Bonjour le monde!, model: code-cushman-001, token: 7            | text: Bonjour le monde!, model: code-cushman-001, token: 7            |
+| text: Bonjour le monde!, model: davinci-codex, token: 7               | text: Bonjour le monde!, model: davinci-codex, token: 7               |
+| text: Bonjour le monde!, model: cushman-codex, token: 7               | text: Bonjour le monde!, model: cushman-codex, token: 7               |
+| text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: text-davinci-edit-001, token: 7       |
+| text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       | text: Bonjour le monde!, model: code-davinci-edit-001, token: 7       |
+| text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      | text: Bonjour le monde!, model: text-embedding-ada-002, token: 4      |
+| text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 | text: Bonjour le monde!, model: text-similarity-davinci-001, token: 7 |
+| text: Ciao mondo!, model: gpt-4, token: 4                             | text: Ciao mondo!, model: gpt-4, token: 4                             |
+| text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     | text: Ciao mondo!, model: gpt-3.5-turbo, token: 4                     |
+| text: Ciao mondo!, model: text-davinci-003, token: 5                  | text: Ciao mondo!, model: text-davinci-003, token: 5                  |
+| text: Ciao mondo!, model: text-davinci-002, token: 5                  | text: Ciao mondo!, model: text-davinci-002, token: 5                  |
+| text: Ciao mondo!, model: text-davinci-001, token: 5                  | text: Ciao mondo!, model: text-davinci-001, token: 5                  |
+| text: Ciao mondo!, model: text-curie-001, token: 5                    | text: Ciao mondo!, model: text-curie-001, token: 5                    |
+| text: Ciao mondo!, model: text-babbage-001, token: 5                  | text: Ciao mondo!, model: text-babbage-001, token: 5                  |
+| text: Ciao mondo!, model: text-ada-001, token: 5                      | text: Ciao mondo!, model: text-ada-001, token: 5                      |
+| text: Ciao mondo!, model: davinci, token: 5                           | text: Ciao mondo!, model: davinci, token: 5                           |
+| text: Ciao mondo!, model: curie, token: 5                             | text: Ciao mondo!, model: curie, token: 5                             |
+| text: Ciao mondo!, model: babbage, token: 5                           | text: Ciao mondo!, model: babbage, token: 5                           |
+| text: Ciao mondo!, model: ada, token: 5                               | text: Ciao mondo!, model: ada, token: 5                               |
+| text: Ciao mondo!, model: code-davinci-002, token: 5                  | text: Ciao mondo!, model: code-davinci-002, token: 5                  |
+| text: Ciao mondo!, model: code-davinci-001, token: 5                  | text: Ciao mondo!, model: code-davinci-001, token: 5                  |
+| text: Ciao mondo!, model: code-cushman-002, token: 5                  | text: Ciao mondo!, model: code-cushman-002, token: 5                  |
+| text: Ciao mondo!, model: code-cushman-001, token: 5                  | text: Ciao mondo!, model: code-cushman-001, token: 5                  |
+| text: Ciao mondo!, model: davinci-codex, token: 5                     | text: Ciao mondo!, model: davinci-codex, token: 5                     |
+| text: Ciao mondo!, model: cushman-codex, token: 5                     | text: Ciao mondo!, model: cushman-codex, token: 5                     |
+| text: Ciao mondo!, model: text-davinci-edit-001, token: 5             | text: Ciao mondo!, model: text-davinci-edit-001, token: 5             |
+| text: Ciao mondo!, model: code-davinci-edit-001, token: 5             | text: Ciao mondo!, model: code-davinci-edit-001, token: 5             |
+| text: Ciao mondo!, model: text-embedding-ada-002, token: 4            | text: Ciao mondo!, model: text-embedding-ada-002, token: 4            |
+| text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       | text: Ciao mondo!, model: text-similarity-davinci-001, token: 5       |
+| text: Hej världen!, model: gpt-4, token: 7                            | text: Hej världen!, model: gpt-4, token: 7                            |
+| text: Hej världen!, model: gpt-3.5-turbo, token: 7                    | text: Hej världen!, model: gpt-3.5-turbo, token: 7                    |
+| text: Hej världen!, model: text-davinci-003, token: 8                 | text: Hej världen!, model: text-davinci-003, token: 8                 |
+| text: Hej världen!, model: text-davinci-002, token: 8                 | text: Hej världen!, model: text-davinci-002, token: 8                 |
+| text: Hej världen!, model: text-davinci-001, token: 8                 | text: Hej världen!, model: text-davinci-001, token: 8                 |
+| text: Hej världen!, model: text-curie-001, token: 8                   | text: Hej världen!, model: text-curie-001, token: 8                   |
+| text: Hej världen!, model: text-babbage-001, token: 8                 | text: Hej världen!, model: text-babbage-001, token: 8                 |
+| text: Hej världen!, model: text-ada-001, token: 8                     | text: Hej världen!, model: text-ada-001, token: 8                     |
+| text: Hej världen!, model: davinci, token: 8                          | text: Hej världen!, model: davinci, token: 8                          |
+| text: Hej världen!, model: curie, token: 8                            | text: Hej världen!, model: curie, token: 8                            |
+| text: Hej världen!, model: babbage, token: 8                          | text: Hej världen!, model: babbage, token: 8                          |
+| text: Hej världen!, model: ada, token: 8                              | text: Hej världen!, model: ada, token: 8                              |
+| text: Hej världen!, model: code-davinci-002, token: 8                 | text: Hej världen!, model: code-davinci-002, token: 8                 |
+| text: Hej världen!, model: code-davinci-001, token: 8                 | text: Hej världen!, model: code-davinci-001, token: 8                 |
+| text: Hej världen!, model: code-cushman-002, token: 8                 | text: Hej världen!, model: code-cushman-002, token: 8                 |
+| text: Hej världen!, model: code-cushman-001, token: 8                 | text: Hej världen!, model: code-cushman-001, token: 8                 |
+| text: Hej världen!, model: davinci-codex, token: 8                    | text: Hej världen!, model: davinci-codex, token: 8                    |
+| text: Hej världen!, model: cushman-codex, token: 8                    | text: Hej världen!, model: cushman-codex, token: 8                    |
+| text: Hej världen!, model: text-davinci-edit-001, token: 8            | text: Hej världen!, model: text-davinci-edit-001, token: 8            |
+| text: Hej världen!, model: code-davinci-edit-001, token: 8            | text: Hej världen!, model: code-davinci-edit-001, token: 8            |
+| text: Hej världen!, model: text-embedding-ada-002, token: 7           | text: Hej världen!, model: text-embedding-ada-002, token: 7           |
+| text: Hej världen!, model: text-similarity-davinci-001, token: 8      | text: Hej världen!, model: text-similarity-davinci-001, token: 8      |
+| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
+| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
+| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
+| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
+| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
+| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
+| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
+| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
+| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
+| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
+| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
+| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
+| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
+| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
+| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
+| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
+| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
+| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
+| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
+| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
+| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
+| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
+| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
+| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
+| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
+| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
+| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
+| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
+| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
+| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
+| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
+| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
+| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
+| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
+| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
+| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
+| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
+| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
+| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
+| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
+| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
+| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
+| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
+| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |
+| text: Hallo wereld!, model: gpt-4, token: 3                           | text: Hallo wereld!, model: gpt-4, token: 3                           |
+| text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   | text: Hallo wereld!, model: gpt-3.5-turbo, token: 3                   |
+| text: Hallo wereld!, model: text-davinci-003, token: 5                | text: Hallo wereld!, model: text-davinci-003, token: 5                |
+| text: Hallo wereld!, model: text-davinci-002, token: 5                | text: Hallo wereld!, model: text-davinci-002, token: 5                |
+| text: Hallo wereld!, model: text-davinci-001, token: 5                | text: Hallo wereld!, model: text-davinci-001, token: 5                |
+| text: Hallo wereld!, model: text-curie-001, token: 5                  | text: Hallo wereld!, model: text-curie-001, token: 5                  |
+| text: Hallo wereld!, model: text-babbage-001, token: 5                | text: Hallo wereld!, model: text-babbage-001, token: 5                |
+| text: Hallo wereld!, model: text-ada-001, token: 5                    | text: Hallo wereld!, model: text-ada-001, token: 5                    |
+| text: Hallo wereld!, model: davinci, token: 5                         | text: Hallo wereld!, model: davinci, token: 5                         |
+| text: Hallo wereld!, model: curie, token: 5                           | text: Hallo wereld!, model: curie, token: 5                           |
+| text: Hallo wereld!, model: babbage, token: 5                         | text: Hallo wereld!, model: babbage, token: 5                         |
+| text: Hallo wereld!, model: ada, token: 5                             | text: Hallo wereld!, model: ada, token: 5                             |
+| text: Hallo wereld!, model: code-davinci-002, token: 5                | text: Hallo wereld!, model: code-davinci-002, token: 5                |
+| text: Hallo wereld!, model: code-davinci-001, token: 5                | text: Hallo wereld!, model: code-davinci-001, token: 5                |
+| text: Hallo wereld!, model: code-cushman-002, token: 5                | text: Hallo wereld!, model: code-cushman-002, token: 5                |
+| text: Hallo wereld!, model: code-cushman-001, token: 5                | text: Hallo wereld!, model: code-cushman-001, token: 5                |
+| text: Hallo wereld!, model: davinci-codex, token: 5                   | text: Hallo wereld!, model: davinci-codex, token: 5                   |
+| text: Hallo wereld!, model: cushman-codex, token: 5                   | text: Hallo wereld!, model: cushman-codex, token: 5                   |
+| text: Hallo wereld!, model: text-davinci-edit-001, token: 5           | text: Hallo wereld!, model: text-davinci-edit-001, token: 5           |
+| text: Hallo wereld!, model: code-davinci-edit-001, token: 5           | text: Hallo wereld!, model: code-davinci-edit-001, token: 5           |
+| text: Hallo wereld!, model: text-embedding-ada-002, token: 3          | text: Hallo wereld!, model: text-embedding-ada-002, token: 3          |
+| text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     | text: Hallo wereld!, model: text-similarity-davinci-001, token: 5     |
+| text: Hallo verden!, model: gpt-4, token: 4                           | text: Hallo verden!, model: gpt-4, token: 4                           |
+| text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   | text: Hallo verden!, model: gpt-3.5-turbo, token: 4                   |
+| text: Hallo verden!, model: text-davinci-003, token: 5                | text: Hallo verden!, model: text-davinci-003, token: 5                |
+| text: Hallo verden!, model: text-davinci-002, token: 5                | text: Hallo verden!, model: text-davinci-002, token: 5                |
+| text: Hallo verden!, model: text-davinci-001, token: 5                | text: Hallo verden!, model: text-davinci-001, token: 5                |
+| text: Hallo verden!, model: text-curie-001, token: 5                  | text: Hallo verden!, model: text-curie-001, token: 5                  |
+| text: Hallo verden!, model: text-babbage-001, token: 5                | text: Hallo verden!, model: text-babbage-001, token: 5                |
+| text: Hallo verden!, model: text-ada-001, token: 5                    | text: Hallo verden!, model: text-ada-001, token: 5                    |
+| text: Hallo verden!, model: davinci, token: 5                         | text: Hallo verden!, model: davinci, token: 5                         |
+| text: Hallo verden!, model: curie, token: 5                           | text: Hallo verden!, model: curie, token: 5                           |
+| text: Hallo verden!, model: babbage, token: 5                         | text: Hallo verden!, model: babbage, token: 5                         |
+| text: Hallo verden!, model: ada, token: 5                             | text: Hallo verden!, model: ada, token: 5                             |
+| text: Hallo verden!, model: code-davinci-002, token: 5                | text: Hallo verden!, model: code-davinci-002, token: 5                |
+| text: Hallo verden!, model: code-davinci-001, token: 5                | text: Hallo verden!, model: code-davinci-001, token: 5                |
+| text: Hallo verden!, model: code-cushman-002, token: 5                | text: Hallo verden!, model: code-cushman-002, token: 5                |
+| text: Hallo verden!, model: code-cushman-001, token: 5                | text: Hallo verden!, model: code-cushman-001, token: 5                |
+| text: Hallo verden!, model: davinci-codex, token: 5                   | text: Hallo verden!, model: davinci-codex, token: 5                   |
+| text: Hallo verden!, model: cushman-codex, token: 5                   | text: Hallo verden!, model: cushman-codex, token: 5                   |
+| text: Hallo verden!, model: text-davinci-edit-001, token: 5           | text: Hallo verden!, model: text-davinci-edit-001, token: 5           |
+| text: Hallo verden!, model: code-davinci-edit-001, token: 5           | text: Hallo verden!, model: code-davinci-edit-001, token: 5           |
+| text: Hallo verden!, model: text-embedding-ada-002, token: 4          | text: Hallo verden!, model: text-embedding-ada-002, token: 4          |
+| text: Hallo verden!, model: text-similarity-davinci-001, token: 5     | text: Hallo verden!, model: text-similarity-davinci-001, token: 5     |

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/pkoukk/tiktoken-go
 go 1.19
 
 require (
+	github.com/dlclark/regexp2 v1.8.1
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dlclark/regexp2 v1.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -1,0 +1,23 @@
+import tiktoken as tk
+import requests
+import time
+
+def benchmark_test(text_list,enc):
+    """
+    Benchmark test
+    :return: None
+    """
+    start = time.perf_counter_ns()
+    for index in range(100000):
+        text = text_list[index]
+        num_tokens = len(enc.encode(text))
+    end = time.perf_counter_ns()
+    print('benchmark test: {} ns/op'.format((end - start)/100000))
+
+if __name__ == '__main__':
+    r = requests.get('https://unicode.org/udhr/assemblies/full_all.txt')
+    text_list = r.text.splitlines()
+    cursor = 0
+    enc=tk.get_encoding('cl100k_base')
+    benchmark_test(text_list,enc)
+

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pkoukk/tiktoken-go"
+)
+
+func BenchmarkEncodingInFullLanguage(b *testing.B) {
+	// Universal Declaration of Human Rights in all languages
+	url := "https://unicode.org/udhr/assemblies/full_all.txt"
+	response, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	responseData, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	responseString := string(responseData)
+	lines := strings.Split(responseString, "\n")
+	tkm, err := tiktoken.EncodingForModel("gpt-4")
+	lineCount := len(lines)
+	if err != nil {
+		log.Fatal(err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		tkm.EncodeOrdinary(lines[n%lineCount])
+	}
+}

--- a/tiktoken.go
+++ b/tiktoken.go
@@ -80,6 +80,10 @@ func (t *Tiktoken) Encode(text string, allowedSpecial []string, disallowedSpecia
 	return tokens
 }
 
+func (t *Tiktoken) EncodeOrdinary(text string) []int {
+	return (t.bpe.encodeOrdinaryNative(text))
+}
+
 func (t *Tiktoken) Decode(tokens []int) string {
 	return string(t.bpe.decodeNative(tokens))
 }

--- a/tiktoken_test.go
+++ b/tiktoken_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestEncoding(t *testing.T) {
 	ass := assert.New(t)
-	enc, err := GetEncoding("cl100k_base")
+	enc, err := EncodingForModel("gpt-3.5-turbo-16k")
 	ass.Nil(err, "Encoding  init should not be nil")
 	tokens := enc.Encode("hello world!你好，世界！", []string{"all"}, []string{"all"})
 	// these tokens are converted from the original python code
@@ -33,7 +33,8 @@ func TestEncoding(t *testing.T) {
 
 func TestDecoding(t *testing.T) {
 	ass := assert.New(t)
-	enc, err := GetEncoding("cl100k_base")
+	// enc, err := GetEncoding("cl100k_base")
+	enc, err := GetEncoding(MODEL_CL100K_BASE)
 	ass.Nil(err, "Encoding  init should not be nil")
 	sourceTokens := []int{15339, 1917, 0, 57668, 53901, 3922, 3574, 244, 98220, 6447}
 	txt := enc.Decode(sourceTokens)


### PR DESCRIPTION
Merging the recent improvements of `main` into the `embed` version.

As an aside, it would be neat if there was some way in the normal package to provide the offline assets on init or something (e.g. having `tiktoken-go` and `tiktoken-go/assets/go.mod`) to avoid any weird constraints when `tiktoken` is included as a dependency by something else and we can't necessarily import the embed version of the library.

e.g. something like `tiktoken.InitWithOfflineData(tiktoken_offline.Data())` 🤷

Thanks!