### PR TITLE
Reduce allocations by using reflect instead of copy

### DIFF
--- a/bpe.go
+++ b/bpe.go
@@ -4,7 +4,7 @@ import (
 	"math"
 )
 
-func bytePairMerge[T any](piece []byte, ranks map[string]int, f func(start, end int) T) []T {
+func bytePairMerge[T any](piece []rune, ranks map[string]int, f func(start, end int) T) []T {
 	parts := make([][2]int, len(piece)+1)
 	for i := 0; i < len(parts); i++ {
 		parts[i][0], parts[i][1] = i, math.MaxInt // use max int as sentinel
@@ -13,7 +13,7 @@ func bytePairMerge[T any](piece []byte, ranks map[string]int, f func(start, end 
 	getRank := func(startIdx, skip int) int {
 		if startIdx+skip+2 < len(parts) {
 			b := piece[parts[startIdx][0]:parts[startIdx+skip+2][0]]
-			rank, ok := ranks[string(b)]
+			rank, ok := ranks[runesToString(b)]
 			if ok {
 				return rank
 			}
@@ -64,12 +64,12 @@ func bytePairMerge[T any](piece []byte, ranks map[string]int, f func(start, end 
 	return out
 }
 
-func bytePairEncode(piece []byte, ranks map[string]int) []int {
+func bytePairEncode(piece []rune, ranks map[string]int) []int {
 	if len(piece) == 1 {
-		v := ranks[string(piece)]
+		v := ranks[runesToString(piece)]
 		return []int{v}
 	}
 	return bytePairMerge(piece, ranks, func(start, end int) int {
-		return ranks[string(piece[start:end])]
+		return ranks[runesToString(piece[start:end])]
 	})
 }

--- a/core_bpe.go
+++ b/core_bpe.go
@@ -74,7 +74,7 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 	regex := bp.tlRegex
 	ret := []int{}
 	lastPieceTokenLen := 0
-	textRunes := []rune(text)
+	textRunes := stringToRunes(text)
 
 	start := 0
 	for {
@@ -86,7 +86,7 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 			nextSpecial = findRegex2StringIndex(temp, specialRegex)
 			if nextSpecial != nil {
 				token := cutRunes(textRunes, startFind+nextSpecial[0], startFind+nextSpecial[1])
-				if _, ok := allowedSpecial[token]; ok {
+				if _, ok := allowedSpecial[runesToString(token)]; ok {
 					break
 				}
 				startFind += nextSpecial[1]
@@ -103,19 +103,19 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 		// Okay, here we go, compare this logic to _encode_ordinary_native
 		for _, mat := range findRegex2AllStringMatchIndex(cutRunes(textRunes, start, end), regex) {
 			piece := cutRunes(textRunes, start+mat[0], start+mat[1])
-			if token, ok := bp.encoder[piece]; ok {
+			if token, ok := bp.encoder[runesToString(piece)]; ok {
 				lastPieceTokenLen = 1
 				ret = append(ret, token)
 				continue
 			}
-			tokens := bytePairEncode([]byte(piece), bp.encoder)
+			tokens := bytePairEncode(piece, bp.encoder)
 			lastPieceTokenLen = len(tokens)
 			ret = append(ret, tokens...)
 		}
 
 		if nextSpecial != nil {
 			temp := cutRunes(textRunes, start+nextSpecial[0], start+nextSpecial[1])
-			token := bp.specialTokensEncoder[temp]
+			token := bp.specialTokensEncoder[runesToString(temp)]
 			ret = append(ret, token)
 			start = start + nextSpecial[1]
 			lastPieceTokenLen = 0
@@ -129,14 +129,14 @@ func (bp *CoreBPE) encodeNative(text string, allowedSpecial map[string]any) ([]i
 
 func (bp *CoreBPE) encodeOrdinaryNative(text string) []int {
 	ret := []int{}
-	textRunes := []rune(text)
-	for _, mat := range findRegex2AllStringMatchIndex(text, bp.tlRegex) {
+	textRunes := stringToRunes(text)
+	for _, mat := range findRegex2AllStringMatchIndex(textRunes, bp.tlRegex) {
 		piece := cutRunes(textRunes, mat[0], mat[1])
-		if token, ok := bp.encoder[piece]; ok {
+		if token, ok := bp.encoder[runesToString(piece)]; ok {
 			ret = append(ret, token)
 			continue
 		}
-		tokens := bytePairEncode([]byte(piece), bp.encoder)
+		tokens := bytePairEncode(piece, bp.encoder)
 		ret = append(ret, tokens...)
 	}
 	return ret
@@ -156,8 +156,8 @@ func (bpe *CoreBPE) decodeNative(tokens []int) []byte {
 	return ret
 }
 
-func findRegex2StringIndex(text string, reg *regexp2.Regexp) []int {
-	m, _ := reg.FindStringMatch(text)
+func findRegex2StringIndex(text []rune, reg *regexp2.Regexp) []int {
+	m, _ := reg.FindRunesMatch(text)
 	if m == nil {
 		return nil
 	}
@@ -167,9 +167,9 @@ func findRegex2StringIndex(text string, reg *regexp2.Regexp) []int {
 	return result
 }
 
-func findRegex2AllStringMatchIndex(text string, reg *regexp2.Regexp) [][]int {
+func findRegex2AllStringMatchIndex(text []rune, reg *regexp2.Regexp) [][]int {
 	var matches [][]int
-	m, _ := reg.FindStringMatch(text)
+	m, _ := reg.FindRunesMatch(text)
 	for m != nil {
 		result := make([]int, 2)
 		result[0] = m.Index
@@ -180,12 +180,12 @@ func findRegex2AllStringMatchIndex(text string, reg *regexp2.Regexp) [][]int {
 	return matches
 }
 
-func cutRunes(runes []rune, start, end int) string {
+func cutRunes(runes []rune, start, end int) []rune {
 	if start < 0 {
 		start = 0
 	}
 	if end > len(runes) {
 		end = len(runes)
 	}
-	return string(runes[start:end])
+	return runes[start:end]
 }

--- a/load.go
+++ b/load.go
@@ -78,7 +78,7 @@ func loadTiktokenBpe(tiktokenBpeFile string) (map[string]int, error) {
 	}
 
 	bpeRanks := make(map[string]int)
-	for _, line := range strings.Split(string(contents), "\n") {
+	for _, line := range strings.Split(bytesToString(contents), "\n") {
 		if line == "" {
 			continue
 		}
@@ -91,7 +91,7 @@ func loadTiktokenBpe(tiktokenBpeFile string) (map[string]int, error) {
 		if err != nil {
 			return nil, err
 		}
-		bpeRanks[string(token)] = rank
+		bpeRanks[bytesToString(token)] = rank
 	}
 	return bpeRanks, nil
 }

--- a/reflect.go
+++ b/reflect.go
@@ -1,0 +1,23 @@
+package tiktoken
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func bytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+func stringToRunes(s string) (b []rune) {
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh.Data = sh.Data
+	bh.Len = sh.Len
+	bh.Cap = sh.Len
+	return b
+}
+
+func runesToString(b []rune) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/regex_test.go
+++ b/regex_test.go
@@ -21,8 +21,8 @@ func TestRegex2Func(t *testing.T) {
 	}
 
 	for _, word := range words {
-		ass.ElementsMatch(re.FindStringIndex(word), findRegex2StringIndex(word, re2))
-		ass.ElementsMatch(re.FindAllStringSubmatchIndex(word, -1), findRegex2AllStringMatchIndex(word, re2))
-		ass.Equal(re.FindString(word), findRegex2StringMatch(word, re2))
+		ass.ElementsMatch(re.FindStringIndex(word), findRegex2StringIndex(stringToRunes(word), re2))
+		ass.ElementsMatch(re.FindAllStringSubmatchIndex(word, -1), findRegex2AllStringMatchIndex(stringToRunes(word), re2))
+		ass.Equal(re.FindString(word), findRegex2StringMatch(stringToRunes(word), re2))
 	}
 }

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -24,6 +24,7 @@ func BenchmarkEncodingInFullLanguage(b *testing.B) {
 		log.Fatal(err)
 	}
 	b.ResetTimer()
+	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		tkm.EncodeOrdinary(lines[n%lineCount])
 	}

--- a/tiktoken.go
+++ b/tiktoken.go
@@ -72,7 +72,7 @@ func (t *Tiktoken) Encode(text string, allowedSpecial []string, disallowedSpecia
 
 	if len(disallowedSpecialSet) > 0 {
 		specialRegex := t.SpecialTokenRegex(disallowedSpecialSet)
-		m := findRegex2StringMatch(text, specialRegex)
+		m := findRegex2StringMatch(stringToRunes(text), specialRegex)
 		if m != "" {
 			panic(fmt.Sprintf("text contains disallowed special token %s", m))
 		}
@@ -83,7 +83,7 @@ func (t *Tiktoken) Encode(text string, allowedSpecial []string, disallowedSpecia
 }
 
 func (t *Tiktoken) EncodeOrdinary(text string) []int {
-	return (t.bpe.encodeOrdinaryNative(text))
+	return t.bpe.encodeOrdinaryNative(text)
 }
 
 func (t *Tiktoken) Decode(tokens []int) string {
@@ -99,8 +99,8 @@ func (t *Tiktoken) SpecialTokenRegex(disallowedSpecialSet map[string]any) *regex
 	return specialRegex
 }
 
-func findRegex2StringMatch(text string, reg *regexp2.Regexp) string {
-	m, _ := reg.FindStringMatch(text)
+func findRegex2StringMatch(text []rune, reg *regexp2.Regexp) string {
+	m, _ := reg.FindRunesMatch(text)
 	if m == nil {
 		return ""
 	}


### PR DESCRIPTION
allocations was reduced by using underlaying slice instead of copy in operations:
- string([]rune)
- []rune(string)
- string([]byte)