### PR TITLE
Configure o series models

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 # Available Encodings
  | Encoding name           | OpenAI models                                        |
  | ----------------------- | ---------------------------------------------------- |
- | `o200k_base`            | `gpt-4o`                                             |
+ | `o200k_base`            | `gpt-4o`, `o3-mini`, `o1`                            |
  | `cl100k_base`           | `gpt-4`, `gpt-3.5-turbo`, `text-embedding-ada-002`, `text-embedding-3-small`, `text-embedding-3-large`   |
  | `p50k_base`             | Codex models, `text-davinci-002`, `text-davinci-003` |
  | `r50k_base` (or `gpt2`) | GPT-3 models like `davinci`                          |
@@ -186,6 +186,8 @@ func NumTokensFromMessages(messages []openai.ChatCompletionMessage, model string
 # Available Models
 | Model name                   | OpenAI models |
 | ---------------------------- | ------------- |
+| o3-*                         | o200k_base    |
+| o1-*                         | o200k_base    |
 | gpt-4o-*                     | o200k_base    |
 | gpt-4-*                      | cl100k_base   |
 | gpt-3.5-turbo-*              | cl100k_base   |

--- a/encoding.go
+++ b/encoding.go
@@ -22,6 +22,8 @@ const (
 
 var MODEL_TO_ENCODING = map[string]string{
 	// chat
+	"o3":            MODEL_O200K_BASE,
+	"o1":            MODEL_O200K_BASE,
 	"gpt-4o":        MODEL_O200K_BASE,
 	"gpt-4":         MODEL_CL100K_BASE,
 	"gpt-3.5-turbo": MODEL_CL100K_BASE,
@@ -67,6 +69,8 @@ var MODEL_TO_ENCODING = map[string]string{
 
 var MODEL_PREFIX_TO_ENCODING = map[string]string{
 	// chat
+	"o3-":            MODEL_O200K_BASE,  // e.g., o3-mini
+	"o1-":            MODEL_O200K_BASE,  // e.g., o1-2024-12-17, etc.
 	"gpt-4o-":        MODEL_O200K_BASE,  // e.g., gpt-4o-2024-05-13, etc.
 	"gpt-4-":         MODEL_CL100K_BASE, // e.g., gpt-4-0314, etc., plus gpt-4-32k
 	"gpt-3.5-turbo-": MODEL_CL100K_BASE, // e.g, gpt-3.5-turbo-0301, -0401, etc.


### PR DESCRIPTION
OpenAI's o series models use the same `o200k_base` tokenizer as `gpt-4o` (ref: [tiktoken](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py#L8-L9)). This PR adds the same here - have been working around this for a while now.  