### PR TITLE
fix: don't cache error responses from BPE file downloads

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -6,18 +6,24 @@ import (
 	"sync"
 )
 
-const ENDOFTEXT string = "<|endoftext|>"
-const FIM_PREFIX string = "<|fim_prefix|>"
-const FIM_MIDDLE string = "<|fim_middle|>"
-const FIM_SUFFIX string = "<|fim_suffix|>"
-const ENDOFPROMPT string = "<|endofprompt|>"
-
 const (
+	ENDOFTEXT         string = "<|endoftext|>"
+	FIM_PREFIX        string = "<|fim_prefix|>"
+	FIM_MIDDLE        string = "<|fim_middle|>"
+	FIM_SUFFIX        string = "<|fim_suffix|>"
+	ENDOFPROMPT       string = "<|endofprompt|>"
 	MODEL_O200K_BASE  string = "o200k_base"
 	MODEL_CL100K_BASE string = "cl100k_base"
 	MODEL_P50K_BASE   string = "p50k_base"
 	MODEL_P50K_EDIT   string = "p50k_edit"
 	MODEL_R50K_BASE   string = "r50k_base"
+
+	OpenAIPublicHost = "https://openaipublic.blob.core.windows.net"
+
+	O200kBasePath  = "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
+	Cl100kBasePath = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+	P50kBasePath   = "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken"
+	R50kBasePath   = "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken"
 )
 
 var MODEL_TO_ENCODING = map[string]string{
@@ -128,7 +134,7 @@ func initEncoding(encodingName string) (*Encoding, error) {
 }
 
 func o200k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe("https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken")
+	ranks, err := bpeLoader.LoadTiktokenBpe(O200kBasePath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +160,7 @@ func o200k_base() (*Encoding, error) {
 }
 
 func cl100k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe("https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken")
+	ranks, err := bpeLoader.LoadTiktokenBpe(Cl100kBasePath)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +180,7 @@ func cl100k_base() (*Encoding, error) {
 }
 
 func p50k_edit() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe("https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken")
+	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBasePath)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +194,7 @@ func p50k_edit() (*Encoding, error) {
 }
 
 func p50k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe("https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken")
+	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBasePath)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +217,7 @@ func p50k_base() (*Encoding, error) {
 }
 
 func r50k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe("https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken")
+	ranks, err := bpeLoader.LoadTiktokenBpe(R50kBasePath)
 	if err != nil {
 		return nil, err
 	}

--- a/encoding.go
+++ b/encoding.go
@@ -18,12 +18,12 @@ const (
 	MODEL_P50K_EDIT   string = "p50k_edit"
 	MODEL_R50K_BASE   string = "r50k_base"
 
-	OpenAIPublicHost = "https://openaipublic.blob.core.windows.net"
+	BpeBaseURL = "https://openaipublic.blob.core.windows.net"
 
-	O200kBasePath  = "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
-	Cl100kBasePath = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
-	P50kBasePath   = "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken"
-	R50kBasePath   = "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken"
+	O200kBaseURL  = "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
+	Cl100kBaseURL = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+	P50kBaseURL   = "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken"
+	R50kBaseURL   = "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken"
 )
 
 var MODEL_TO_ENCODING = map[string]string{
@@ -134,7 +134,7 @@ func initEncoding(encodingName string) (*Encoding, error) {
 }
 
 func o200k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe(O200kBasePath)
+	ranks, err := bpeLoader.LoadTiktokenBpe(O200kBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func o200k_base() (*Encoding, error) {
 }
 
 func cl100k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe(Cl100kBasePath)
+	ranks, err := bpeLoader.LoadTiktokenBpe(Cl100kBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func cl100k_base() (*Encoding, error) {
 }
 
 func p50k_edit() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBasePath)
+	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func p50k_edit() (*Encoding, error) {
 }
 
 func p50k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBasePath)
+	ranks, err := bpeLoader.LoadTiktokenBpe(P50kBaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func p50k_base() (*Encoding, error) {
 }
 
 func r50k_base() (*Encoding, error) {
-	ranks, err := bpeLoader.LoadTiktokenBpe(R50kBasePath)
+	ranks, err := bpeLoader.LoadTiktokenBpe(R50kBaseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/load.go
+++ b/load.go
@@ -33,6 +33,11 @@ func readFile(blobpath string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"unexpected HTTP status %d (%s) for URL %s",
+			resp.StatusCode, resp.Status, blobpath)
+	}
 	return io.ReadAll(resp.Body)
 }
 

--- a/tiktoken_test.go
+++ b/tiktoken_test.go
@@ -1,9 +1,14 @@
 package tiktoken
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncoding(t *testing.T) {
@@ -39,4 +44,82 @@ func TestDecoding(t *testing.T) {
 	sourceTokens := []int{15339, 1917, 0, 57668, 53901, 3922, 3574, 244, 98220, 6447}
 	txt := enc.Decode(sourceTokens)
 	ass.Equal("hello world!你好，世界！", txt, "Decoding should be equal")
+}
+
+type urlRewriteLoader struct {
+	realBase string
+	fakeBase string
+	inner    BpeLoader
+}
+
+func (u *urlRewriteLoader) LoadTiktokenBpe(url string) (map[string]int, error) {
+	url = strings.Replace(url, u.realBase, u.fakeBase, 1)
+	return u.inner.LoadTiktokenBpe(url)
+}
+
+func TestGetEncoding_ErrorResponseNotCached(t *testing.T) {
+	cacheDir := t.TempDir()
+	t.Setenv("TIKTOKEN_CACHE_DIR", cacheDir)
+
+	ass := assert.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusNotFound)
+	}))
+	t.Cleanup(func() {
+		ts.Close()
+		SetBpeLoader(NewDefaultBpeLoader())
+	})
+
+	loader := &urlRewriteLoader{
+		realBase: OpenAIPublicHost,
+		fakeBase: ts.URL,
+		inner:    NewDefaultBpeLoader(),
+	}
+	SetBpeLoader(loader)
+
+	got, err := GetEncoding(MODEL_O200K_BASE)
+	ass.Nil(got)
+	ass.Error(err, "expected error when fetching encoding with bad response")
+
+	entries, err := os.ReadDir(cacheDir)
+	ass.NoError(err)
+	ass.Empty(entries, "expected empty cache dir after error")
+}
+
+func TestEncodingForModel_Names(t *testing.T) {
+	for model := range MODEL_TO_ENCODING {
+		// we don't support gpt2 model so far
+		if model == "gpt2" {
+			continue
+		}
+		t.Run("Check model "+model, func(t *testing.T) {
+			testEncodingForModel(t, model)
+		})
+	}
+}
+
+func TestEncodingForModel_Prefixes(t *testing.T) {
+	for prefix := range MODEL_PREFIX_TO_ENCODING {
+		t.Run("Check prefix "+prefix, func(t *testing.T) {
+			testEncodingForModel(t, prefix)
+		})
+	}
+}
+
+func testEncodingForModel(t *testing.T, model string) {
+	t.Helper()
+
+	text := "hello world"
+	ass := assert.New(t)
+	req := require.New(t)
+
+	tkm, err := EncodingForModel(model)
+	req.NoErrorf(err, "error getting encoding for model %q: %v", model, err)
+	ass.NotNil(tkm, "Encoding for model %s should not be nil", model)
+
+	encText := tkm.Encode(text, nil, nil)
+	ass.Len(encText, 2, "Encoding len should be equal")
+
+	decText := tkm.Decode(encText)
+	ass.Equal(text, decText, "decoding mismatch - want: %s, got: %s", text, decText)
 }

--- a/tiktoken_test.go
+++ b/tiktoken_test.go
@@ -71,7 +71,7 @@ func TestGetEncoding_ErrorResponseNotCached(t *testing.T) {
 	})
 
 	loader := &urlRewriteLoader{
-		realBase: OpenAIPublicHost,
+		realBase: BpeBaseURL,
 		fakeBase: ts.URL,
 		inner:    NewDefaultBpeLoader(),
 	}


### PR DESCRIPTION
## Fix: don't cache error HTTP responses when loading BPE files

  Fixes #71                                                                                                          
   
  ### Problem                                                                                                        
                  
  When fetching a tiktoken BPE file over HTTP, a non-200 response (e.g. 404, 500) was not treated as an error — the
  response body was read and written to the cache regardless. 

  ### Changes

  **`load.go`**
  - Added HTTP status check in `readFile`: returns an error for any non-200 response, preventing bad data from ever
  reaching the cache write path.

  **`encoding.go`**
  - Extracted hardcoded BPE file URLs into exported constants (`BpeBaseURL`, `O200kBaseURL`, `Cl100kBaseURL`,
  `P50kBaseURL`, `R50kBaseURL`) to avoid magic strings and enable URL rewriting in tests.

  **`tiktoken_test.go`**
  - Added `TestGetEncoding_ErrorResponseNotCached`: spins up a mock HTTP server returning 404, verifies that the call returns an error and leaves the cache directory empty.
  - Added `TestEncodingForModel_Names` and `TestEncodingForModel_Prefixes`: smoke-test encoding round-trips for every  model name and prefix defined in the package.
